### PR TITLE
perf: fix N+1 API calls in S3 buckets and ACM certificates list

### DIFF
--- a/custom/acm/certificates/dao.go
+++ b/custom/acm/certificates/dao.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/acm/types"
 	appaws "github.com/clawscli/claws/internal/aws"
 	"github.com/clawscli/claws/internal/dao"
-	"github.com/clawscli/claws/internal/log"
 )
 
 // CertificateDAO provides data access for ACM certificates
@@ -45,18 +44,11 @@ func (d *CertificateDAO) List(ctx context.Context) ([]dao.Resource, error) {
 		return nil, err
 	}
 
-	// Get certificate details for each summary
+	// CertificateSummary contains all fields needed for list view
+	// No need for N+1 DescribeCertificate calls
 	resources := make([]dao.Resource, 0, len(summaries))
 	for _, cert := range summaries {
-		describeOutput, err := d.client.DescribeCertificate(ctx, &acm.DescribeCertificateInput{
-			CertificateArn: cert.CertificateArn,
-		})
-		if err != nil {
-			log.Warn("failed to describe certificate", "arn", appaws.Str(cert.CertificateArn), "error", err)
-			continue
-		}
-
-		resources = append(resources, NewCertificateResource(describeOutput.Certificate))
+		resources = append(resources, NewCertificateResourceFromSummary(cert))
 	}
 
 	return resources, nil
@@ -97,10 +89,11 @@ func (d *CertificateDAO) Delete(ctx context.Context, id string) error {
 // CertificateResource wraps an ACM certificate
 type CertificateResource struct {
 	dao.BaseResource
-	Item *types.CertificateDetail
+	Item    *types.CertificateDetail  // Full details (from Get/DescribeCertificate)
+	Summary *types.CertificateSummary // Summary (from List, avoids N+1 calls)
 }
 
-// NewCertificateResource creates a new CertificateResource
+// NewCertificateResource creates a new CertificateResource from CertificateDetail
 func NewCertificateResource(cert *types.CertificateDetail) *CertificateResource {
 	arn := appaws.Str(cert.CertificateArn)
 	domain := appaws.Str(cert.DomainName)
@@ -120,105 +113,208 @@ func NewCertificateResource(cert *types.CertificateDetail) *CertificateResource 
 	}
 }
 
+// NewCertificateResourceFromSummary creates a new CertificateResource from CertificateSummary
+// Used for list view to avoid N+1 DescribeCertificate calls
+func NewCertificateResourceFromSummary(cert types.CertificateSummary) *CertificateResource {
+	arn := appaws.Str(cert.CertificateArn)
+	domain := appaws.Str(cert.DomainName)
+
+	return &CertificateResource{
+		BaseResource: dao.BaseResource{
+			ID:   arn,
+			Name: domain,
+			ARN:  arn,
+			Tags: make(map[string]string),
+			Data: cert,
+		},
+		Summary: &cert,
+	}
+}
+
 // DomainName returns the primary domain name
 func (r *CertificateResource) DomainName() string {
-	return appaws.Str(r.Item.DomainName)
+	if r.Item != nil {
+		return appaws.Str(r.Item.DomainName)
+	}
+	if r.Summary != nil {
+		return appaws.Str(r.Summary.DomainName)
+	}
+	return ""
 }
 
 // Status returns the certificate status
 func (r *CertificateResource) Status() string {
-	return string(r.Item.Status)
+	if r.Item != nil {
+		return string(r.Item.Status)
+	}
+	if r.Summary != nil {
+		return string(r.Summary.Status)
+	}
+	return ""
 }
 
 // Type returns the certificate type (IMPORTED or AMAZON_ISSUED)
 func (r *CertificateResource) Type() string {
-	return string(r.Item.Type)
+	if r.Item != nil {
+		return string(r.Item.Type)
+	}
+	if r.Summary != nil {
+		return string(r.Summary.Type)
+	}
+	return ""
 }
 
 // KeyAlgorithm returns the key algorithm
 func (r *CertificateResource) KeyAlgorithm() string {
-	return string(r.Item.KeyAlgorithm)
+	if r.Item != nil {
+		return string(r.Item.KeyAlgorithm)
+	}
+	if r.Summary != nil {
+		return string(r.Summary.KeyAlgorithm)
+	}
+	return ""
 }
 
 // Issuer returns the certificate issuer
 func (r *CertificateResource) Issuer() string {
+	if r.Item == nil {
+		return ""
+	}
 	return appaws.Str(r.Item.Issuer)
 }
 
 // NotBefore returns the not before date as string
 func (r *CertificateResource) NotBefore() string {
-	if r.Item.NotBefore != nil {
+	if r.Item != nil && r.Item.NotBefore != nil {
 		return r.Item.NotBefore.Format("2006-01-02")
+	}
+	if r.Summary != nil && r.Summary.NotBefore != nil {
+		return r.Summary.NotBefore.Format("2006-01-02")
 	}
 	return ""
 }
 
 // NotAfter returns the not after date as string
 func (r *CertificateResource) NotAfter() string {
-	if r.Item.NotAfter != nil {
+	if r.Item != nil && r.Item.NotAfter != nil {
 		return r.Item.NotAfter.Format("2006-01-02")
+	}
+	if r.Summary != nil && r.Summary.NotAfter != nil {
+		return r.Summary.NotAfter.Format("2006-01-02")
 	}
 	return ""
 }
 
 // CreatedAt returns the creation date as string
 func (r *CertificateResource) CreatedAt() string {
-	if r.Item.CreatedAt != nil {
+	if r.Item != nil && r.Item.CreatedAt != nil {
 		return r.Item.CreatedAt.Format("2006-01-02 15:04:05")
+	}
+	if r.Summary != nil && r.Summary.CreatedAt != nil {
+		return r.Summary.CreatedAt.Format("2006-01-02 15:04:05")
 	}
 	return ""
 }
 
 // IssuedAt returns the issued date as string
 func (r *CertificateResource) IssuedAt() string {
-	if r.Item.IssuedAt != nil {
+	if r.Item != nil && r.Item.IssuedAt != nil {
 		return r.Item.IssuedAt.Format("2006-01-02 15:04:05")
+	}
+	if r.Summary != nil && r.Summary.IssuedAt != nil {
+		return r.Summary.IssuedAt.Format("2006-01-02 15:04:05")
 	}
 	return ""
 }
 
 // RenewalEligibility returns the renewal eligibility
 func (r *CertificateResource) RenewalEligibility() string {
-	return string(r.Item.RenewalEligibility)
+	if r.Item != nil {
+		return string(r.Item.RenewalEligibility)
+	}
+	if r.Summary != nil {
+		return string(r.Summary.RenewalEligibility)
+	}
+	return ""
 }
 
 // InUseBy returns the resources using this certificate
+// Only available from Item (detail view), Summary only has bool flag
 func (r *CertificateResource) InUseBy() []string {
-	return r.Item.InUseBy
+	if r.Item != nil {
+		return r.Item.InUseBy
+	}
+	return nil
+}
+
+// IsInUse returns whether the certificate is in use (available from Summary)
+func (r *CertificateResource) IsInUse() *bool {
+	if r.Item != nil {
+		inUse := len(r.Item.InUseBy) > 0
+		return &inUse
+	}
+	if r.Summary != nil {
+		return r.Summary.InUse
+	}
+	return nil
 }
 
 // SubjectAlternativeNames returns the SANs
 func (r *CertificateResource) SubjectAlternativeNames() []string {
-	return r.Item.SubjectAlternativeNames
+	if r.Item != nil {
+		return r.Item.SubjectAlternativeNames
+	}
+	if r.Summary != nil {
+		return r.Summary.SubjectAlternativeNameSummaries
+	}
+	return nil
 }
 
 // DomainValidationOptions returns the domain validation options
 func (r *CertificateResource) DomainValidationOptions() []types.DomainValidation {
+	if r.Item == nil {
+		return nil
+	}
 	return r.Item.DomainValidationOptions
 }
 
 // Serial returns the certificate serial number
 func (r *CertificateResource) Serial() string {
+	if r.Item == nil {
+		return ""
+	}
 	return appaws.Str(r.Item.Serial)
 }
 
 // SignatureAlgorithm returns the signature algorithm
 func (r *CertificateResource) SignatureAlgorithm() string {
+	if r.Item == nil {
+		return ""
+	}
 	return appaws.Str(r.Item.SignatureAlgorithm)
 }
 
 // Subject returns the certificate subject
 func (r *CertificateResource) Subject() string {
+	if r.Item == nil {
+		return ""
+	}
 	return appaws.Str(r.Item.Subject)
 }
 
 // CertificateAuthorityArn returns the private CA ARN (for private certificates)
 func (r *CertificateResource) CertificateAuthorityArn() string {
+	if r.Item == nil {
+		return ""
+	}
 	return appaws.Str(r.Item.CertificateAuthorityArn)
 }
 
 // KeyUsages returns the key usages
 func (r *CertificateResource) KeyUsages() []string {
+	if r.Item == nil {
+		return nil
+	}
 	usages := make([]string, len(r.Item.KeyUsages))
 	for i, ku := range r.Item.KeyUsages {
 		usages[i] = string(ku.Name)
@@ -228,12 +324,15 @@ func (r *CertificateResource) KeyUsages() []string {
 
 // ExtendedKeyUsages returns the extended key usages
 func (r *CertificateResource) ExtendedKeyUsages() []types.ExtendedKeyUsage {
+	if r.Item == nil {
+		return nil
+	}
 	return r.Item.ExtendedKeyUsages
 }
 
 // CertificateTransparencyLogging returns the certificate transparency logging status
 func (r *CertificateResource) CertificateTransparencyLogging() string {
-	if r.Item.Options != nil {
+	if r.Item != nil && r.Item.Options != nil {
 		return string(r.Item.Options.CertificateTransparencyLoggingPreference)
 	}
 	return ""
@@ -241,36 +340,57 @@ func (r *CertificateResource) CertificateTransparencyLogging() string {
 
 // RenewalSummary returns the renewal summary (for AMAZON_ISSUED certificates)
 func (r *CertificateResource) RenewalSummary() *types.RenewalSummary {
+	if r.Item == nil {
+		return nil
+	}
 	return r.Item.RenewalSummary
 }
 
 // FailureReason returns the failure reason (when status is FAILED)
 func (r *CertificateResource) FailureReason() string {
+	if r.Item == nil {
+		return ""
+	}
 	return string(r.Item.FailureReason)
 }
 
 // RevocationReason returns the revocation reason (when status is REVOKED)
 func (r *CertificateResource) RevocationReason() string {
+	if r.Item == nil {
+		return ""
+	}
 	return string(r.Item.RevocationReason)
 }
 
 // RevokedAt returns the revocation date
 func (r *CertificateResource) RevokedAt() string {
-	if r.Item.RevokedAt != nil {
+	if r.Item != nil && r.Item.RevokedAt != nil {
 		return r.Item.RevokedAt.Format("2006-01-02 15:04:05")
+	}
+	if r.Summary != nil && r.Summary.RevokedAt != nil {
+		return r.Summary.RevokedAt.Format("2006-01-02 15:04:05")
 	}
 	return ""
 }
 
 // ImportedAt returns the import date (for IMPORTED certificates)
 func (r *CertificateResource) ImportedAt() string {
-	if r.Item.ImportedAt != nil {
+	if r.Item != nil && r.Item.ImportedAt != nil {
 		return r.Item.ImportedAt.Format("2006-01-02 15:04:05")
+	}
+	if r.Summary != nil && r.Summary.ImportedAt != nil {
+		return r.Summary.ImportedAt.Format("2006-01-02 15:04:05")
 	}
 	return ""
 }
 
 // ManagedBy returns the service managing the certificate
 func (r *CertificateResource) ManagedBy() string {
-	return string(r.Item.ManagedBy)
+	if r.Item != nil {
+		return string(r.Item.ManagedBy)
+	}
+	if r.Summary != nil {
+		return string(r.Summary.ManagedBy)
+	}
+	return ""
 }

--- a/custom/acm/certificates/render.go
+++ b/custom/acm/certificates/render.go
@@ -69,9 +69,8 @@ func getExpires(r dao.Resource) string {
 
 func getInUse(r dao.Resource) string {
 	if cert, ok := r.(*CertificateResource); ok {
-		count := len(cert.InUseBy())
-		if count > 0 {
-			return fmt.Sprintf("%d", count)
+		if inUse := cert.IsInUse(); inUse != nil && *inUse {
+			return "Yes"
 		}
 		return "-"
 	}
@@ -151,7 +150,7 @@ func (r *CertificateRenderer) RenderDetail(resource dao.Resource) string {
 	if notAfter := cert.NotAfter(); notAfter != "" {
 		d.Field("Valid Until", notAfter)
 		// Calculate days until expiry
-		if cert.Item.NotAfter != nil {
+		if cert.Item != nil && cert.Item.NotAfter != nil {
 			daysLeft := int(time.Until(*cert.Item.NotAfter).Hours() / 24)
 			if daysLeft >= 0 {
 				d.Field("Days Until Expiry", fmt.Sprintf("%d days", daysLeft))

--- a/custom/acm/certificates/resource_test.go
+++ b/custom/acm/certificates/resource_test.go
@@ -1,0 +1,194 @@
+package certificates
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/acm/types"
+)
+
+func TestNewCertificateResource(t *testing.T) {
+	notAfter := time.Date(2025, 12, 31, 23, 59, 59, 0, time.UTC)
+	cert := &types.CertificateDetail{
+		CertificateArn: aws.String("arn:aws:acm:us-east-1:123456789012:certificate/abc123"),
+		DomainName:     aws.String("example.com"),
+		Status:         types.CertificateStatusIssued,
+		Type:           types.CertificateTypeAmazonIssued,
+		KeyAlgorithm:   types.KeyAlgorithmRsa2048,
+		NotAfter:       &notAfter,
+		InUseBy:        []string{"arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/my-lb/123"},
+	}
+
+	resource := NewCertificateResource(cert)
+
+	tests := []struct {
+		name     string
+		got      string
+		expected string
+	}{
+		{"GetID", resource.GetID(), "arn:aws:acm:us-east-1:123456789012:certificate/abc123"},
+		{"GetName", resource.GetName(), "example.com"},
+		{"GetARN", resource.GetARN(), "arn:aws:acm:us-east-1:123456789012:certificate/abc123"},
+		{"DomainName", resource.DomainName(), "example.com"},
+		{"Status", resource.Status(), "ISSUED"},
+		{"Type", resource.Type(), "AMAZON_ISSUED"},
+		{"KeyAlgorithm", resource.KeyAlgorithm(), "RSA_2048"},
+		{"NotAfter", resource.NotAfter(), "2025-12-31"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.expected {
+				t.Errorf("%s = %q, want %q", tt.name, tt.got, tt.expected)
+			}
+		})
+	}
+
+	// Test InUseBy
+	inUseBy := resource.InUseBy()
+	if len(inUseBy) != 1 {
+		t.Errorf("InUseBy() len = %d, want 1", len(inUseBy))
+	}
+
+	// Test IsInUse
+	isInUse := resource.IsInUse()
+	if isInUse == nil || !*isInUse {
+		t.Error("IsInUse() should be true")
+	}
+}
+
+func TestNewCertificateResourceFromSummary(t *testing.T) {
+	notAfter := time.Date(2025, 12, 31, 23, 59, 59, 0, time.UTC)
+	inUse := true
+	summary := types.CertificateSummary{
+		CertificateArn:     aws.String("arn:aws:acm:us-east-1:123456789012:certificate/abc123"),
+		DomainName:         aws.String("example.com"),
+		Status:             types.CertificateStatusIssued,
+		Type:               types.CertificateTypeAmazonIssued,
+		KeyAlgorithm:       types.KeyAlgorithmRsa2048,
+		NotAfter:           &notAfter,
+		InUse:              &inUse,
+		RenewalEligibility: types.RenewalEligibilityEligible,
+	}
+
+	resource := NewCertificateResourceFromSummary(summary)
+
+	tests := []struct {
+		name     string
+		got      string
+		expected string
+	}{
+		{"GetID", resource.GetID(), "arn:aws:acm:us-east-1:123456789012:certificate/abc123"},
+		{"GetName", resource.GetName(), "example.com"},
+		{"DomainName", resource.DomainName(), "example.com"},
+		{"Status", resource.Status(), "ISSUED"},
+		{"Type", resource.Type(), "AMAZON_ISSUED"},
+		{"KeyAlgorithm", resource.KeyAlgorithm(), "RSA_2048"},
+		{"NotAfter", resource.NotAfter(), "2025-12-31"},
+		{"RenewalEligibility", resource.RenewalEligibility(), "ELIGIBLE"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.expected {
+				t.Errorf("%s = %q, want %q", tt.name, tt.got, tt.expected)
+			}
+		})
+	}
+
+	// Summary doesn't have InUseBy list, only InUse bool
+	inUseBy := resource.InUseBy()
+	if inUseBy != nil {
+		t.Errorf("InUseBy() should be nil for Summary, got %v", inUseBy)
+	}
+
+	// But IsInUse should work
+	isInUse := resource.IsInUse()
+	if isInUse == nil || !*isInUse {
+		t.Error("IsInUse() should be true")
+	}
+}
+
+func TestCertificateResource_IsInUse(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource *CertificateResource
+		expected *bool
+	}{
+		{
+			name: "Item with InUseBy",
+			resource: &CertificateResource{
+				Item: &types.CertificateDetail{
+					InUseBy: []string{"arn:aws:elasticloadbalancing:..."},
+				},
+			},
+			expected: aws.Bool(true),
+		},
+		{
+			name: "Item without InUseBy",
+			resource: &CertificateResource{
+				Item: &types.CertificateDetail{
+					InUseBy: []string{},
+				},
+			},
+			expected: aws.Bool(false),
+		},
+		{
+			name: "Summary InUse true",
+			resource: &CertificateResource{
+				Summary: &types.CertificateSummary{
+					InUse: aws.Bool(true),
+				},
+			},
+			expected: aws.Bool(true),
+		},
+		{
+			name: "Summary InUse false",
+			resource: &CertificateResource{
+				Summary: &types.CertificateSummary{
+					InUse: aws.Bool(false),
+				},
+			},
+			expected: aws.Bool(false),
+		},
+		{
+			name:     "Neither Item nor Summary",
+			resource: &CertificateResource{},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.resource.IsInUse()
+			if tt.expected == nil {
+				if got != nil {
+					t.Errorf("IsInUse() = %v, want nil", *got)
+				}
+			} else if got == nil {
+				t.Errorf("IsInUse() = nil, want %v", *tt.expected)
+			} else if *got != *tt.expected {
+				t.Errorf("IsInUse() = %v, want %v", *got, *tt.expected)
+			}
+		})
+	}
+}
+
+func TestCertificateResource_NilFields(t *testing.T) {
+	// Test with completely nil Item
+	resource := &CertificateResource{}
+
+	if resource.DomainName() != "" {
+		t.Errorf("DomainName() = %q, want empty", resource.DomainName())
+	}
+	if resource.Status() != "" {
+		t.Errorf("Status() = %q, want empty", resource.Status())
+	}
+	if resource.NotAfter() != "" {
+		t.Errorf("NotAfter() = %q, want empty", resource.NotAfter())
+	}
+	if resource.InUseBy() != nil {
+		t.Errorf("InUseBy() = %v, want nil", resource.InUseBy())
+	}
+}

--- a/custom/s3/buckets/resource_test.go
+++ b/custom/s3/buckets/resource_test.go
@@ -130,3 +130,42 @@ func TestBucketResource_NilName(t *testing.T) {
 		t.Errorf("BucketName = %q, want empty string for nil name", resource.BucketName)
 	}
 }
+
+func TestBucketResource_BucketRegion(t *testing.T) {
+	// Test that BucketRegion from ListBuckets response is handled correctly
+	bucket := types.Bucket{
+		Name:         aws.String("regional-bucket"),
+		BucketRegion: aws.String("ap-northeast-1"),
+	}
+
+	resource := NewBucketResource(bucket)
+
+	// BucketRegion is set separately in DAO.List(), so initially empty
+	if resource.Region != "" {
+		t.Errorf("Region should be empty initially, got %q", resource.Region)
+	}
+
+	// Simulate what DAO.List() does
+	if bucket.BucketRegion != nil {
+		resource.Region = *bucket.BucketRegion
+	}
+
+	if resource.Region != "ap-northeast-1" {
+		t.Errorf("Region = %q, want %q", resource.Region, "ap-northeast-1")
+	}
+}
+
+func TestBucketResource_BucketRegionNil(t *testing.T) {
+	// Test that nil BucketRegion doesn't cause issues
+	bucket := types.Bucket{
+		Name:         aws.String("no-region-bucket"),
+		BucketRegion: nil,
+	}
+
+	resource := NewBucketResource(bucket)
+
+	// Region should remain empty when BucketRegion is nil
+	if resource.Region != "" {
+		t.Errorf("Region should be empty for nil BucketRegion, got %q", resource.Region)
+	}
+}

--- a/custom/s3vectors/buckets/render.go
+++ b/custom/s3vectors/buckets/render.go
@@ -21,7 +21,6 @@ func NewVectorBucketRenderer() *VectorBucketRenderer {
 			Resource: "buckets",
 			Cols: []render.Column{
 				{Name: "NAME", Width: 50, Getter: getName},
-				{Name: "ENCRYPTION", Width: 12, Getter: getEncryption},
 				{Name: "CREATED", Width: 20, Getter: getCreated},
 				{Name: "AGE", Width: 10, Getter: getAge},
 			},
@@ -36,13 +35,6 @@ func getName(r dao.Resource) string {
 	return r.GetName()
 }
 
-func getEncryption(r dao.Resource) string {
-	if bucket, ok := r.(*VectorBucketResource); ok {
-		return bucket.EncryptionType()
-	}
-	return ""
-}
-
 func getCreated(r dao.Resource) string {
 	if bucket, ok := r.(*VectorBucketResource); ok {
 		return bucket.CreationDate()
@@ -52,7 +44,7 @@ func getCreated(r dao.Resource) string {
 
 func getAge(r dao.Resource) string {
 	if bucket, ok := r.(*VectorBucketResource); ok {
-		if bucket.fromDetail && bucket.Item != nil && bucket.Item.CreationTime != nil {
+		if bucket.Item != nil && bucket.Item.CreationTime != nil {
 			return render.FormatAge(*bucket.Item.CreationTime)
 		}
 		if bucket.Summary != nil && bucket.Summary.CreationTime != nil {

--- a/custom/s3vectors/buckets/resource_test.go
+++ b/custom/s3vectors/buckets/resource_test.go
@@ -1,0 +1,139 @@
+package buckets
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3vectors/types"
+)
+
+func TestNewVectorBucketResource(t *testing.T) {
+	creationTime := time.Date(2024, 6, 15, 10, 30, 0, 0, time.UTC)
+	bucket := &types.VectorBucket{
+		VectorBucketName: aws.String("my-vector-bucket"),
+		VectorBucketArn:  aws.String("arn:aws:s3vectors:us-east-1:123456789012:bucket/my-vector-bucket"),
+		CreationTime:     &creationTime,
+		EncryptionConfiguration: &types.EncryptionConfiguration{
+			SseType: types.SseTypeAes256,
+		},
+	}
+
+	resource := NewVectorBucketResource(bucket)
+
+	tests := []struct {
+		name     string
+		got      string
+		expected string
+	}{
+		{"GetID", resource.GetID(), "my-vector-bucket"},
+		{"GetName", resource.GetName(), "my-vector-bucket"},
+		{"GetARN", resource.GetARN(), "arn:aws:s3vectors:us-east-1:123456789012:bucket/my-vector-bucket"},
+		{"BucketName", resource.BucketName(), "my-vector-bucket"},
+		{"EncryptionType", resource.EncryptionType(), "AES256"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.expected {
+				t.Errorf("%s = %q, want %q", tt.name, tt.got, tt.expected)
+			}
+		})
+	}
+
+	// Test CreationDate
+	if resource.CreationDate() != "2024-06-15 10:30:00" {
+		t.Errorf("CreationDate() = %q, want %q", resource.CreationDate(), "2024-06-15 10:30:00")
+	}
+
+	// Test Item is set
+	if resource.Item == nil {
+		t.Error("Item should not be nil")
+	}
+	if resource.Summary != nil {
+		t.Error("Summary should be nil for resource created from detail")
+	}
+}
+
+func TestNewVectorBucketResourceFromSummary(t *testing.T) {
+	creationTime := time.Date(2024, 6, 15, 10, 30, 0, 0, time.UTC)
+	summary := types.VectorBucketSummary{
+		VectorBucketName: aws.String("my-vector-bucket"),
+		VectorBucketArn:  aws.String("arn:aws:s3vectors:us-east-1:123456789012:bucket/my-vector-bucket"),
+		CreationTime:     &creationTime,
+	}
+
+	resource := NewVectorBucketResourceFromSummary(summary)
+
+	tests := []struct {
+		name     string
+		got      string
+		expected string
+	}{
+		{"GetID", resource.GetID(), "my-vector-bucket"},
+		{"GetName", resource.GetName(), "my-vector-bucket"},
+		{"GetARN", resource.GetARN(), "arn:aws:s3vectors:us-east-1:123456789012:bucket/my-vector-bucket"},
+		{"BucketName", resource.BucketName(), "my-vector-bucket"},
+		{"CreationDate", resource.CreationDate(), "2024-06-15 10:30:00"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.expected {
+				t.Errorf("%s = %q, want %q", tt.name, tt.got, tt.expected)
+			}
+		})
+	}
+
+	// EncryptionType should return "-" when only Summary is available
+	if resource.EncryptionType() != "-" {
+		t.Errorf("EncryptionType() = %q, want %q for Summary-only resource", resource.EncryptionType(), "-")
+	}
+
+	// Summary is set, Item is nil
+	if resource.Summary == nil {
+		t.Error("Summary should not be nil")
+	}
+	if resource.Item != nil {
+		t.Error("Item should be nil for resource created from summary")
+	}
+}
+
+func TestVectorBucketResource_KmsEncryption(t *testing.T) {
+	bucket := &types.VectorBucket{
+		VectorBucketName: aws.String("kms-bucket"),
+		VectorBucketArn:  aws.String("arn:aws:s3vectors:us-east-1:123456789012:bucket/kms-bucket"),
+		EncryptionConfiguration: &types.EncryptionConfiguration{
+			SseType:   types.SseTypeAwsKms,
+			KmsKeyArn: aws.String("arn:aws:kms:us-east-1:123456789012:key/abc123"),
+		},
+	}
+
+	resource := NewVectorBucketResource(bucket)
+
+	if resource.EncryptionType() != "aws:kms" {
+		t.Errorf("EncryptionType() = %q, want %q", resource.EncryptionType(), "aws:kms")
+	}
+
+	if resource.KmsKeyArn() != "arn:aws:kms:us-east-1:123456789012:key/abc123" {
+		t.Errorf("KmsKeyArn() = %q, want KMS key ARN", resource.KmsKeyArn())
+	}
+}
+
+func TestVectorBucketResource_NilFields(t *testing.T) {
+	// Test with completely empty resource
+	resource := &VectorBucketResource{}
+
+	if resource.BucketName() != "" {
+		t.Errorf("BucketName() = %q, want empty", resource.BucketName())
+	}
+	if resource.CreationDate() != "" {
+		t.Errorf("CreationDate() = %q, want empty", resource.CreationDate())
+	}
+	if resource.EncryptionType() != "-" {
+		t.Errorf("EncryptionType() = %q, want %q", resource.EncryptionType(), "-")
+	}
+	if resource.KmsKeyArn() != "" {
+		t.Errorf("KmsKeyArn() = %q, want empty", resource.KmsKeyArn())
+	}
+}


### PR DESCRIPTION
## Summary
- Eliminate N+1 API calls in list views for S3 buckets and ACM certificates
- ACM: Use `CertificateSummary` from `ListCertificates` (contains all needed fields) instead of calling `DescribeCertificate` for each certificate
- S3: Set `MaxBuckets` param to include `BucketRegion` in response, eliminating `GetBucketLocation` calls