### PR TITLE
fix: increase detail view label width to 32 chars, add tgw alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ Quick shortcuts for common services:
 | `ri` | Reserved Instances |
 | `sp` | Savings Plans |
 | `odcr` | Capacity Reservations |
+| `tgw` | Transit Gateways |
 | `agentcore` | Bedrock AgentCore |
 | `kb` | Bedrock Agent Knowledge Bases |
 | `agent` | Bedrock Agent Agents |

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -120,6 +120,7 @@ func defaultAliases() map[string]string {
 		"ri":            "risp/reserved-instances",
 		"sp":            "risp/savings-plans",
 		"odcr":          "ec2/capacity-reservations",
+		"tgw":           "vpc/transit-gateways",
 		"profile":       "local/profile",
 		"profiles":      "local/profile",
 	}

--- a/internal/render/detail.go
+++ b/internal/render/detail.go
@@ -47,7 +47,7 @@ func DefaultDetailStyles() DetailStyles {
 	styles := DetailStyles{
 		Title:   lipgloss.NewStyle().Bold(true).Foreground(t.Primary),
 		Section: lipgloss.NewStyle().Bold(true).Foreground(t.Secondary).MarginTop(1),
-		Label:   lipgloss.NewStyle().Foreground(t.TextDim).Width(20),
+		Label:   lipgloss.NewStyle().Foreground(t.TextDim).Width(32),
 		Value:   lipgloss.NewStyle().Foreground(t.Text),
 		Dim:     lipgloss.NewStyle().Foreground(t.TextDim),
 		Success: lipgloss.NewStyle().Foreground(t.Success),


### PR DESCRIPTION
## Summary
- Increase detail label width 20→32 chars to fix truncation on Transit Gateway fields (e.g., "Propagation Default Route Table")
- Add `tgw` alias for `vpc/transit-gateways`