### PR TITLE
refactor: remove --demo flag and demoMode functionality

### DIFF
--- a/cmd/claws/main.go
+++ b/cmd/claws/main.go
@@ -326,14 +326,7 @@ func main() {
 			opts.readOnly = true
 		}
 	}
-	if !opts.demoMode {
-		if v := os.Getenv("CLAWS_DEMO"); v == "1" || v == "true" {
-			opts.demoMode = true
-		}
-	}
-
 	cfg.SetReadOnly(opts.readOnly)
-	cfg.SetDemoMode(opts.demoMode)
 	if opts.envCreds {
 		// Use environment credentials, ignore ~/.aws config
 		cfg.UseEnvOnly()
@@ -377,8 +370,7 @@ type cliOptions struct {
 	profile  string
 	region   string
 	readOnly bool
-	demoMode bool
-	envCreds bool // Use environment credentials (ignore ~/.aws config)
+	envCreds bool
 	logFile  string
 }
 
@@ -404,8 +396,6 @@ func parseFlags() cliOptions {
 			}
 		case arg == "-ro" || arg == "--read-only":
 			opts.readOnly = true
-		case arg == "--demo":
-			opts.demoMode = true
 		case arg == "-e" || arg == "--env":
 			opts.envCreds = true
 		case arg == "-l" || arg == "--log-file":
@@ -448,8 +438,6 @@ func printUsage() {
 	fmt.Println("        Useful for instance profiles, ECS task roles, Lambda, etc.")
 	fmt.Println("  -ro, --read-only")
 	fmt.Println("        Run in read-only mode (disable dangerous actions)")
-	fmt.Println("  --demo")
-	fmt.Println("        Demo mode (mask account IDs)")
 	fmt.Println("  -l, --log-file <path>")
 	fmt.Println("        Enable debug logging to specified file")
 	fmt.Println("  -v, --version")
@@ -459,5 +447,4 @@ func printUsage() {
 	fmt.Println()
 	fmt.Println("Environment Variables:")
 	fmt.Println("  CLAWS_READ_ONLY=1|true   Enable read-only mode")
-	fmt.Println("  CLAWS_DEMO=1|true        Enable demo mode")
 }

--- a/custom/ec2/securitygroups/render.go
+++ b/custom/ec2/securitygroups/render.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	appaws "github.com/clawscli/claws/internal/aws"
-	"github.com/clawscli/claws/internal/config"
 	"github.com/clawscli/claws/internal/dao"
 	"github.com/clawscli/claws/internal/render"
 )
@@ -113,7 +112,7 @@ func (r *SecurityGroupRenderer) RenderDetail(resource dao.Resource) string {
 	d.Field("Group Name", sg.GetName())
 	d.Field("VPC ID", sg.VpcID())
 	if sg.Item.OwnerId != nil {
-		d.Field("Owner ID", config.Global().MaskAccountID(*sg.Item.OwnerId))
+		d.Field("Owner ID", *sg.Item.OwnerId)
 	}
 	d.Field("Description", sg.Description())
 
@@ -254,7 +253,7 @@ func (r *SecurityGroupRenderer) RenderSummary(resource dao.Resource) []render.Su
 
 	// Row 4: Owner ID if available
 	if sg.Item.OwnerId != nil {
-		fields = append(fields, render.SummaryField{Label: "Owner", Value: config.Global().MaskAccountID(*sg.Item.OwnerId)})
+		fields = append(fields, render.SummaryField{Label: "Owner", Value: *sg.Item.OwnerId})
 	}
 
 	return fields

--- a/custom/local/profile/render.go
+++ b/custom/local/profile/render.go
@@ -108,11 +108,8 @@ func maskAccessKey(key string) string {
 	if key == "" {
 		return ""
 	}
-	if config.Global().DemoMode() {
-		return "AKIA************"
-	}
 	if len(key) <= 8 {
-		return "****" // Always mask short keys for security
+		return "****"
 	}
 	return key[:4] + "****" + key[len(key)-4:]
 }
@@ -211,7 +208,7 @@ func (r *ProfileRenderer) RenderDetail(resource dao.Resource) string {
 			d.Field("SSO Region", data.SSORegion)
 		}
 		if data.SSOAccountID != "" {
-			d.Field("Account ID", config.Global().MaskAccountID(data.SSOAccountID))
+			d.Field("Account ID", data.SSOAccountID)
 		}
 		if data.SSORoleName != "" {
 			d.Field("Role Name", data.SSORoleName)

--- a/custom/vpc/internetgateways/render.go
+++ b/custom/vpc/internetgateways/render.go
@@ -2,7 +2,6 @@ package internetgateways
 
 import (
 	appaws "github.com/clawscli/claws/internal/aws"
-	"github.com/clawscli/claws/internal/config"
 	"github.com/clawscli/claws/internal/dao"
 	"github.com/clawscli/claws/internal/render"
 )
@@ -65,7 +64,7 @@ func NewInternetGatewayRenderer() render.Renderer {
 					Width: 14,
 					Getter: func(r dao.Resource) string {
 						if igwr, ok := r.(*InternetGatewayResource); ok {
-							return config.Global().MaskAccountID(igwr.OwnerId())
+							return igwr.OwnerId()
 						}
 						return ""
 					},
@@ -92,7 +91,7 @@ func (r *InternetGatewayRenderer) RenderDetail(resource dao.Resource) string {
 	d.Field("Internet Gateway ID", igwr.GetID())
 	d.FieldStyled("State", igwr.AttachmentState(), render.StateColorer()(igwr.AttachmentState()))
 	if igwr.Item.OwnerId != nil {
-		d.Field("Owner ID", config.Global().MaskAccountID(*igwr.Item.OwnerId))
+		d.Field("Owner ID", *igwr.Item.OwnerId)
 	}
 
 	// Attachments
@@ -130,7 +129,7 @@ func (r *InternetGatewayRenderer) RenderSummary(resource dao.Resource) []render.
 	}
 
 	if igwr.Item.OwnerId != nil {
-		fields = append(fields, render.SummaryField{Label: "Owner", Value: config.Global().MaskAccountID(*igwr.Item.OwnerId)})
+		fields = append(fields, render.SummaryField{Label: "Owner", Value: *igwr.Item.OwnerId})
 	}
 
 	return fields

--- a/custom/vpc/subnets/render.go
+++ b/custom/vpc/subnets/render.go
@@ -5,7 +5,6 @@ import (
 
 	"charm.land/lipgloss/v2"
 	appaws "github.com/clawscli/claws/internal/aws"
-	"github.com/clawscli/claws/internal/config"
 	"github.com/clawscli/claws/internal/dao"
 	"github.com/clawscli/claws/internal/render"
 )
@@ -161,7 +160,7 @@ func (r *SubnetRenderer) RenderDetail(resource dao.Resource) string {
 	// Owner
 	if sr.Item.OwnerId != nil {
 		d.Section("Owner")
-		d.Field("Owner ID", config.Global().MaskAccountID(*sr.Item.OwnerId))
+		d.Field("Owner ID", *sr.Item.OwnerId)
 	}
 
 	// Tags

--- a/custom/vpc/vpcs/render.go
+++ b/custom/vpc/vpcs/render.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	appaws "github.com/clawscli/claws/internal/aws"
-	"github.com/clawscli/claws/internal/config"
 	"github.com/clawscli/claws/internal/dao"
 	"github.com/clawscli/claws/internal/render"
 )
@@ -112,7 +111,7 @@ func (r *VPCRenderer) RenderDetail(resource dao.Resource) string {
 	d.Field("Default VPC", fmt.Sprintf("%v", vr.IsDefault()))
 	d.Field("Tenancy", vr.Tenancy())
 	if vr.Item.OwnerId != nil {
-		d.Field("Owner ID", config.Global().MaskAccountID(*vr.Item.OwnerId))
+		d.Field("Owner ID", *vr.Item.OwnerId)
 	}
 
 	// DNS Settings
@@ -187,7 +186,7 @@ func (r *VPCRenderer) RenderSummary(resource dao.Resource) []render.SummaryField
 	}
 
 	if vr.Item.OwnerId != nil {
-		fields = append(fields, render.SummaryField{Label: "Owner", Value: config.Global().MaskAccountID(*vr.Item.OwnerId)})
+		fields = append(fields, render.SummaryField{Label: "Owner", Value: *vr.Item.OwnerId})
 	}
 
 	return fields

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,9 +5,6 @@ import (
 	"sync"
 )
 
-// DemoAccountID is the masked account ID shown in demo mode
-const DemoAccountID = "123456789012"
-
 // Profile resource ID constants for stable identification
 const (
 	// ProfileIDSDKDefault is the resource ID for SDK default credential mode
@@ -134,7 +131,6 @@ type Config struct {
 	accountID string
 	warnings  []string
 	readOnly  bool
-	demoMode  bool
 }
 
 var (
@@ -193,13 +189,10 @@ func (c *Config) UseProfile(name string) {
 	c.SetSelection(NamedProfile(name))
 }
 
-// AccountID returns the current AWS account ID (masked in demo mode)
+// AccountID returns the current AWS account ID
 func (c *Config) AccountID() string {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	if c.demoMode {
-		return DemoAccountID
-	}
 	return c.accountID
 }
 
@@ -208,30 +201,6 @@ func (c *Config) SetAccountID(id string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.accountID = id
-}
-
-// SetDemoMode enables or disables demo mode
-func (c *Config) SetDemoMode(enabled bool) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.demoMode = enabled
-}
-
-// DemoMode returns whether demo mode is enabled
-func (c *Config) DemoMode() bool {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return c.demoMode
-}
-
-// MaskAccountID masks an account ID if demo mode is enabled
-func (c *Config) MaskAccountID(id string) string {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	if c.demoMode && id != "" {
-		return DemoAccountID
-	}
-	return id
 }
 
 // Warnings returns any startup warnings

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -122,34 +122,3 @@ func TestGlobal(t *testing.T) {
 		t.Error("Global() should return same instance")
 	}
 }
-
-func TestConfig_DemoMode(t *testing.T) {
-	cfg := &Config{accountID: "111122223333"}
-
-	// Demo mode disabled - should return real account ID
-	if cfg.AccountID() != "111122223333" {
-		t.Errorf("AccountID() = %q, want %q", cfg.AccountID(), "111122223333")
-	}
-
-	// Enable demo mode
-	cfg.SetDemoMode(true)
-	if !cfg.DemoMode() {
-		t.Error("DemoMode() = false, want true")
-	}
-
-	// Should return masked account ID
-	if cfg.AccountID() != DemoAccountID {
-		t.Errorf("AccountID() = %q, want %q (demo mode)", cfg.AccountID(), DemoAccountID)
-	}
-
-	// MaskAccountID should also mask
-	if cfg.MaskAccountID("999988887777") != DemoAccountID {
-		t.Errorf("MaskAccountID() = %q, want %q", cfg.MaskAccountID("999988887777"), DemoAccountID)
-	}
-
-	// Disable demo mode
-	cfg.SetDemoMode(false)
-	if cfg.AccountID() != "111122223333" {
-		t.Errorf("AccountID() = %q, want %q after disabling demo mode", cfg.AccountID(), "111122223333")
-	}
-}

--- a/internal/render/detail.go
+++ b/internal/render/detail.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
-	"github.com/clawscli/claws/internal/config"
 	"github.com/clawscli/claws/internal/ui"
 )
 
@@ -135,9 +134,8 @@ func (d *DetailBuilder) Tag(key, value string) *DetailBuilder {
 
 // Tags renders a "Tags" section with all tags from a map.
 // Keys are sorted alphabetically for consistent display.
-// Tags are hidden in demo mode to avoid exposing sensitive information.
 func (d *DetailBuilder) Tags(tags map[string]string) *DetailBuilder {
-	if len(tags) == 0 || config.Global().DemoMode() {
+	if len(tags) == 0 {
 		return d
 	}
 	d.Section("Tags")


### PR DESCRIPTION
## Summary
- Remove `--demo` CLI flag and `CLAWS_DEMO` environment variable
- Remove all demoMode-related code: `DemoAccountID`, `SetDemoMode()`, `DemoMode()`, `MaskAccountID()`
- Display account IDs directly without masking

This simplifies the codebase by removing unused demo functionality.