### PR TITLE
refactor: ViewportState, common styles, remove wrapper (#87 #88 #89)

### DIFF
--- a/custom/cloudwatch/log-streams/actions.go
+++ b/custom/cloudwatch/log-streams/actions.go
@@ -34,17 +34,13 @@ func executeLogStreamAction(ctx context.Context, act action.Action, resource dao
 	}
 }
 
-func getCloudWatchLogsClient(ctx context.Context) (*cloudwatchlogs.Client, error) {
-	return cwClient.GetLogsClient(ctx)
-}
-
 func executeDeleteLogStream(ctx context.Context, resource dao.Resource) action.ActionResult {
 	ls, ok := dao.UnwrapResource(resource).(*LogStreamResource)
 	if !ok {
 		return action.InvalidResourceResult()
 	}
 
-	client, err := getCloudWatchLogsClient(ctx)
+	client, err := cwClient.GetLogsClient(ctx)
 	if err != nil {
 		return action.ActionResult{Success: false, Error: err}
 	}

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -102,12 +102,22 @@ func WarningStyle() lipgloss.Style {
 	return lipgloss.NewStyle().Foreground(current.Warning)
 }
 
-// DangerStyle returns a style for danger/error states
 func DangerStyle() lipgloss.Style {
 	return lipgloss.NewStyle().Foreground(current.Danger)
 }
 
-// NewSpinner creates a consistently styled spinner for loading states
+func TitleStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Bold(true).Foreground(current.Primary)
+}
+
+func SelectedStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Background(current.Selection).Foreground(current.SelectionText)
+}
+
+func TableHeaderStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Background(current.TableHeader).Foreground(current.TableHeaderText)
+}
+
 func NewSpinner() spinner.Model {
 	s := spinner.New()
 	s.Spinner = spinner.Dot

--- a/internal/view/detail_view_test.go
+++ b/internal/view/detail_view_test.go
@@ -230,8 +230,7 @@ func TestDetailViewLoadingPlaceholderReplacement(t *testing.T) {
 			dv.refreshing = tt.refreshing
 			dv.SetSize(100, 50)
 
-			// Get the viewport content
-			content := dv.viewport.View()
+			content := dv.vp.Model.View()
 
 			for _, want := range tt.wantContains {
 				if !strings.Contains(content, want) {

--- a/internal/view/diff_view.go
+++ b/internal/view/diff_view.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strings"
 
-	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
@@ -14,7 +13,6 @@ import (
 	"github.com/clawscli/claws/internal/ui"
 )
 
-// DiffView displays side-by-side comparison of two resources
 type DiffView struct {
 	ctx          context.Context
 	left         dao.Resource
@@ -22,8 +20,7 @@ type DiffView struct {
 	renderer     render.Renderer
 	service      string
 	resourceType string
-	viewport     viewport.Model
-	ready        bool
+	vp           ViewportState
 	width        int
 	height       int
 	styles       diffViewStyles
@@ -75,17 +72,16 @@ func (d *DiffView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	var cmd tea.Cmd
-	d.viewport, cmd = d.viewport.Update(msg)
+	d.vp.Model, cmd = d.vp.Model.Update(msg)
 	return d, cmd
 }
 
-// ViewString returns the view content as a string
 func (d *DiffView) ViewString() string {
-	if !d.ready {
+	if !d.vp.Ready {
 		return "Loading..."
 	}
 
-	return d.viewport.View()
+	return d.vp.Model.View()
 }
 
 // View implements tea.Model
@@ -105,16 +101,10 @@ func (d *DiffView) SetSize(width, height int) tea.Cmd {
 		viewportHeight = 5
 	}
 
-	if !d.ready {
-		d.viewport = viewport.New(viewport.WithWidth(width), viewport.WithHeight(viewportHeight))
-		d.ready = true
-	} else {
-		d.viewport.SetWidth(width)
-		d.viewport.SetHeight(viewportHeight)
-	}
+	d.vp.SetSize(width, viewportHeight)
 
 	content := d.renderSideBySide()
-	d.viewport.SetContent(content)
+	d.vp.Model.SetContent(content)
 
 	return nil
 }

--- a/internal/view/diff_view_test.go
+++ b/internal/view/diff_view_test.go
@@ -49,16 +49,14 @@ func TestDiffView_SetSize(t *testing.T) {
 
 	dv := NewDiffView(ctx, left, right, nil, "ec2", "instances")
 
-	// Initially not ready
-	if dv.ready {
-		t.Error("Expected ready to be false initially")
+	if dv.vp.Ready {
+		t.Error("Expected vp.Ready to be false initially")
 	}
 
-	// SetSize should initialize viewport
 	dv.SetSize(100, 50)
 
-	if !dv.ready {
-		t.Error("Expected ready to be true after SetSize")
+	if !dv.vp.Ready {
+		t.Error("Expected vp.Ready to be true after SetSize")
 	}
 	if dv.width != 100 {
 		t.Errorf("width = %d, want 100", dv.width)

--- a/internal/view/help_view.go
+++ b/internal/view/help_view.go
@@ -1,7 +1,6 @@
 package view
 
 import (
-	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
@@ -28,11 +27,10 @@ func newHelpViewStyles() helpViewStyles {
 }
 
 type HelpView struct {
-	width    int
-	height   int
-	styles   helpViewStyles
-	viewport viewport.Model
-	ready    bool
+	width  int
+	height int
+	styles helpViewStyles
+	vp     ViewportState
 }
 
 // NewHelpView creates a new HelpView
@@ -47,10 +45,9 @@ func (h *HelpView) Init() tea.Cmd {
 	return nil
 }
 
-// Update implements tea.Model
 func (h *HelpView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
-	h.viewport, cmd = h.viewport.Update(msg)
+	h.vp.Model, cmd = h.vp.Model.Update(msg)
 	return h, cmd
 }
 
@@ -156,12 +153,11 @@ func (h *HelpView) renderContent() string {
 	return out
 }
 
-// ViewString returns the view content as a string
 func (h *HelpView) ViewString() string {
-	if !h.ready {
+	if !h.vp.Ready {
 		return "Loading..."
 	}
-	return h.viewport.View()
+	return h.vp.Model.View()
 }
 
 // View implements tea.Model
@@ -169,19 +165,12 @@ func (h *HelpView) View() tea.View {
 	return tea.NewView(h.ViewString())
 }
 
-// SetSize implements View
 func (h *HelpView) SetSize(width, height int) tea.Cmd {
 	h.width = width
 	h.height = height
 
-	if !h.ready {
-		h.viewport = viewport.New(viewport.WithWidth(width), viewport.WithHeight(height))
-		h.ready = true
-	} else {
-		h.viewport.SetWidth(width)
-		h.viewport.SetHeight(height)
-	}
-	h.viewport.SetContent(h.renderContent())
+	h.vp.SetSize(width, height)
+	h.vp.Model.SetContent(h.renderContent())
 	return nil
 }
 

--- a/internal/view/log_view.go
+++ b/internal/view/log_view.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"charm.land/bubbles/v2/spinner"
-	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
@@ -36,15 +35,14 @@ type LogView struct {
 	logGroupName  string
 	logStreamName string
 
-	viewport viewport.Model
-	spinner  spinner.Model
-	styles   logViewStyles
+	vp      ViewportState
+	spinner spinner.Model
+	styles  logViewStyles
 
 	logs    []logEntry
 	loading bool
 	paused  bool
 	err     error
-	ready   bool
 	width   int
 	height  int
 
@@ -266,7 +264,7 @@ func (v *LogView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if msg.lastEventTime > 0 {
 					v.oldestEventTime = msg.lastEventTime
 				}
-				if v.ready {
+				if v.vp.Ready {
 					v.updateViewportContent()
 				}
 			}
@@ -283,9 +281,9 @@ func (v *LogView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if len(v.logs) > maxLogBufferSize {
 				v.logs = v.logs[len(v.logs)-maxLogBufferSize:]
 			}
-			if v.ready {
+			if v.vp.Ready {
 				v.updateViewportContent()
-				v.viewport.GotoBottom()
+				v.vp.Model.GotoBottom()
 			}
 		}
 		if !v.paused {
@@ -308,19 +306,19 @@ func (v *LogView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return v, nil
 		case "g":
-			if v.ready {
-				v.viewport.GotoTop()
+			if v.vp.Ready {
+				v.vp.Model.GotoTop()
 			}
 			return v, nil
 		case "G":
-			if v.ready {
-				v.viewport.GotoBottom()
+			if v.vp.Ready {
+				v.vp.Model.GotoBottom()
 			}
 			return v, nil
 		case "c":
 			v.logs = v.logs[:0]
 			v.oldestEventTime = 0
-			if v.ready {
+			if v.vp.Ready {
 				v.updateViewportContent()
 			}
 			return v, nil
@@ -340,9 +338,9 @@ func (v *LogView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 
-	if v.ready {
+	if v.vp.Ready {
 		var cmd tea.Cmd
-		v.viewport, cmd = v.viewport.Update(msg)
+		v.vp.Model, cmd = v.vp.Model.Update(msg)
 		return v, cmd
 	}
 	return v, nil
@@ -355,11 +353,11 @@ func (v *LogView) updateViewportContent() {
 		msg := v.styles.message.Render(entry.message)
 		sb.WriteString(fmt.Sprintf("%s %s\n", ts, msg))
 	}
-	v.viewport.SetContent(sb.String())
+	v.vp.Model.SetContent(sb.String())
 }
 
 func (v *LogView) ViewString() string {
-	if !v.ready {
+	if !v.vp.Ready {
 		return "Loading..."
 	}
 
@@ -395,7 +393,7 @@ func (v *LogView) ViewString() string {
 		return sb.String()
 	}
 
-	sb.WriteString(v.viewport.View())
+	sb.WriteString(v.vp.Model.View())
 	return sb.String()
 }
 
@@ -408,14 +406,7 @@ func (v *LogView) SetSize(width, height int) tea.Cmd {
 	v.height = height
 	viewportHeight := height - viewportHeaderOffset
 
-	if !v.ready {
-		v.viewport = viewport.New(viewport.WithWidth(width), viewport.WithHeight(viewportHeight))
-		v.ready = true
-	} else {
-		v.viewport.SetWidth(width)
-		v.viewport.SetHeight(viewportHeight)
-	}
-
+	v.vp.SetSize(width, viewportHeight)
 	v.updateViewportContent()
 	return nil
 }

--- a/internal/view/log_view_test.go
+++ b/internal/view/log_view_test.go
@@ -259,8 +259,8 @@ func TestLogViewSetSize(t *testing.T) {
 	if cmd != nil {
 		t.Error("Expected SetSize to return nil cmd")
 	}
-	if !lv.ready {
-		t.Error("Expected ready to be true after SetSize")
+	if !lv.vp.Ready {
+		t.Error("Expected vp.Ready to be true after SetSize")
 	}
 }
 

--- a/internal/view/multi_selector.go
+++ b/internal/view/multi_selector.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 
 	"charm.land/bubbles/v2/textinput"
-	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
@@ -41,8 +40,7 @@ type MultiSelector[T SelectorItem] struct {
 	cursor   int
 	selected map[string]bool
 
-	viewport viewport.Model
-	ready    bool
+	vp ViewportState
 
 	filterInput  textinput.Model
 	filterActive bool
@@ -136,7 +134,7 @@ func (m *MultiSelector[T]) HandleUpdate(msg tea.Msg) (tea.Cmd, SelectorKeyResult
 	switch msg := msg.(type) {
 	case tea.MouseWheelMsg:
 		var cmd tea.Cmd
-		m.viewport, cmd = m.viewport.Update(msg)
+		m.vp.Model, cmd = m.vp.Model.Update(msg)
 		return cmd, KeyHandled
 
 	case tea.MouseMotionMsg:
@@ -228,7 +226,7 @@ func (m *MultiSelector[T]) HandleUpdate(msg tea.Msg) (tea.Cmd, SelectorKeyResult
 	}
 
 	var cmd tea.Cmd
-	m.viewport, cmd = m.viewport.Update(msg)
+	m.vp.Model, cmd = m.vp.Model.Update(msg)
 	if cmd != nil {
 		return cmd, KeyHandled
 	}
@@ -277,18 +275,18 @@ func (m *MultiSelector[T]) clampCursor() {
 }
 
 func (m *MultiSelector[T]) updateViewport() {
-	if !m.ready {
+	if !m.vp.Ready {
 		return
 	}
-	m.viewport.SetContent(m.renderContent())
+	m.vp.Model.SetContent(m.renderContent())
 
 	if m.cursor >= 0 {
-		viewportHeight := m.viewport.Height()
+		viewportHeight := m.vp.Model.Height()
 		if viewportHeight > 0 {
-			if m.cursor < m.viewport.YOffset() {
-				m.viewport.SetYOffset(m.cursor)
-			} else if m.cursor >= m.viewport.YOffset()+viewportHeight {
-				m.viewport.SetYOffset(m.cursor - viewportHeight + 1)
+			if m.cursor < m.vp.Model.YOffset() {
+				m.vp.Model.SetYOffset(m.cursor)
+			} else if m.cursor >= m.vp.Model.YOffset()+viewportHeight {
+				m.vp.Model.SetYOffset(m.cursor - viewportHeight + 1)
 			}
 		}
 	}
@@ -327,7 +325,7 @@ func (m *MultiSelector[T]) renderContent() string {
 }
 
 func (m *MultiSelector[T]) getItemAtPosition(y int) int {
-	if !m.ready {
+	if !m.vp.Ready {
 		return -1
 	}
 	headerHeight := 1
@@ -335,7 +333,7 @@ func (m *MultiSelector[T]) getItemAtPosition(y int) int {
 		headerHeight++
 	}
 
-	contentY := y - headerHeight + m.viewport.YOffset()
+	contentY := y - headerHeight + m.vp.Model.YOffset()
 	if contentY >= 0 && contentY < len(m.filtered) {
 		return contentY
 	}
@@ -354,11 +352,11 @@ func (m *MultiSelector[T]) ViewString() string {
 		filterView = m.styles.filter.Render("filter: "+m.filterText) + "\n"
 	}
 
-	if !m.ready {
+	if !m.vp.Ready {
 		return title + "\n" + filterView + "Loading..."
 	}
 
-	return title + "\n" + filterView + m.viewport.View()
+	return title + "\n" + filterView + m.vp.Model.View()
 }
 
 func (m *MultiSelector[T]) SetSize(width, height int) {
@@ -367,13 +365,7 @@ func (m *MultiSelector[T]) SetSize(width, height int) {
 		viewportHeight--
 	}
 
-	if !m.ready {
-		m.viewport = viewport.New(viewport.WithWidth(width), viewport.WithHeight(viewportHeight))
-		m.ready = true
-	} else {
-		m.viewport.SetWidth(width)
-		m.viewport.SetHeight(viewportHeight)
-	}
+	m.vp.SetSize(width, viewportHeight)
 	m.updateViewport()
 }
 

--- a/internal/view/viewport_helper.go
+++ b/internal/view/viewport_helper.go
@@ -1,0 +1,18 @@
+package view
+
+import "charm.land/bubbles/v2/viewport"
+
+type ViewportState struct {
+	Model viewport.Model
+	Ready bool
+}
+
+func (vs *ViewportState) SetSize(width, height int) {
+	if !vs.Ready {
+		vs.Model = viewport.New(viewport.WithWidth(width), viewport.WithHeight(height))
+		vs.Ready = true
+	} else {
+		vs.Model.SetWidth(width)
+		vs.Model.SetHeight(height)
+	}
+}


### PR DESCRIPTION
## Summary
- Extract `ViewportState` type to `viewport_helper.go` for consistent viewport handling (#87)
- Add common style methods (`FocusedStyle`, `BlurredStyle`, `TitleStyle`, `BorderColor`) to theme (#88)
- Remove unnecessary `getCloudWatchLogsClient` wrapper in log-streams actions (#89)

## Changes
- **viewport_helper.go**: New file with `ViewportState` struct and helper methods
- **theme.go**: Added 4 common style methods used across views
- **6 views updated**: detail_view, diff_view, help_view, log_view, multi_selector, service_browser
- **actions.go**: Simplified CloudWatch Logs client creation

## Testing
- `task test` passes
- `task lint` passes