### PR TITLE
feat: add theming support via config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,16 @@ startup:                  # Applied on launch if present
   regions:
     - us-east-1
     - us-west-2
+
+theme:                    # Custom color scheme (all optional)
+  primary: "#aa55ff"      # Hex (#RGB or #RRGGBB) or ANSI 256 number
+  secondary: "33"
+  accent: "#86d9e6"
+  success: "#2ecc71"
+  warning: "#f39c12"
+  danger: "#e74c3c"
+  badge_foreground: "16"  # READ-ONLY badge text
+  badge_background: "214" # READ-ONLY badge background
 ```
 
 The config file is **not created automatically**. Create it manually if needed.

--- a/cmd/claws/main.go
+++ b/cmd/claws/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/clawscli/claws/internal/config"
 	"github.com/clawscli/claws/internal/log"
 	"github.com/clawscli/claws/internal/registry"
+	"github.com/clawscli/claws/internal/ui"
 )
 
 // version is set by ldflags during build
@@ -52,6 +53,8 @@ func main() {
 	}
 
 	applyStartupConfig(opts, fileCfg, cfg)
+
+	ui.ApplyConfig(fileCfg.GetTheme())
 
 	// Validate and resolve startup service/resource
 	var startupPath *app.StartupPath

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -62,6 +62,46 @@ type StartupConfig struct {
 	Profile string   `yaml:"profile,omitempty"`
 }
 
+// ThemeConfig holds custom color overrides for the UI theme.
+// Colors can be specified as hex ("#ff5733", "#f00") or ANSI 256 numbers ("170").
+// Empty strings use the default color.
+type ThemeConfig struct {
+	// Primary colors
+	Primary   string `yaml:"primary,omitempty"`
+	Secondary string `yaml:"secondary,omitempty"`
+	Accent    string `yaml:"accent,omitempty"`
+
+	// Text colors
+	Text       string `yaml:"text,omitempty"`
+	TextBright string `yaml:"text_bright,omitempty"`
+	TextDim    string `yaml:"text_dim,omitempty"`
+	TextMuted  string `yaml:"text_muted,omitempty"`
+
+	// Semantic colors
+	Success string `yaml:"success,omitempty"`
+	Warning string `yaml:"warning,omitempty"`
+	Danger  string `yaml:"danger,omitempty"`
+	Info    string `yaml:"info,omitempty"`
+	Pending string `yaml:"pending,omitempty"`
+
+	// UI element colors
+	Border          string `yaml:"border,omitempty"`
+	BorderHighlight string `yaml:"border_highlight,omitempty"`
+	Background      string `yaml:"background,omitempty"`
+	BackgroundAlt   string `yaml:"background_alt,omitempty"`
+	Selection       string `yaml:"selection,omitempty"`
+	SelectionText   string `yaml:"selection_text,omitempty"`
+
+	// Table colors
+	TableHeader     string `yaml:"table_header,omitempty"`
+	TableHeaderText string `yaml:"table_header_text,omitempty"`
+	TableBorder     string `yaml:"table_border,omitempty"`
+
+	// Badge colors
+	BadgeForeground string `yaml:"badge_foreground,omitempty"`
+	BadgeBackground string `yaml:"badge_background,omitempty"`
+}
+
 type FileConfig struct {
 	mu                  sync.RWMutex      `yaml:"-"`
 	persistenceOverride *bool             `yaml:"-"` // CLI flag override (not persisted)
@@ -70,6 +110,7 @@ type FileConfig struct {
 	CloudWatch          CloudWatchConfig  `yaml:"cloudwatch,omitempty"`
 	Persistence         PersistenceConfig `yaml:"persistence"`
 	Startup             StartupConfig     `yaml:"startup,omitempty"`
+	Theme               ThemeConfig       `yaml:"theme,omitempty"`
 }
 
 // Duration wraps time.Duration for YAML marshal/unmarshal as string (e.g., "5s", "30s")
@@ -330,4 +371,8 @@ func (c *FileConfig) GetStartup() ([]string, string) {
 		return result{append([]string(nil), c.Startup.Regions...), c.Startup.Profile}
 	})
 	return r.regions, r.profile
+}
+
+func (c *FileConfig) GetTheme() ThemeConfig {
+	return withRLock(&c.mu, func() ThemeConfig { return c.Theme })
 }

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -1,11 +1,56 @@
 package ui
 
 import (
+	"fmt"
 	"image/color"
+	"log/slog"
+	"regexp"
+	"strconv"
+	"strings"
 
 	"charm.land/bubbles/v2/spinner"
 	"charm.land/lipgloss/v2"
+
+	"github.com/clawscli/claws/internal/config"
 )
+
+var (
+	hex6Re = regexp.MustCompile(`^#[0-9A-Fa-f]{6}$`)
+	hex3Re = regexp.MustCompile(`^#[0-9A-Fa-f]{3}$`)
+)
+
+// ParseColor parses a color string and returns a lipgloss color.
+// Accepts hex (#RGB, #RRGGBB) or ANSI 256 numbers (0-255).
+// Returns nil, nil for empty strings (caller should use default).
+// Returns nil, error for invalid color strings.
+func ParseColor(s string) (color.Color, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, nil
+	}
+
+	if strings.HasPrefix(s, "#") {
+		if hex6Re.MatchString(s) {
+			return lipgloss.Color(s), nil
+		}
+		if hex3Re.MatchString(s) {
+			// Expand #RGB to #RRGGBB
+			r, g, b := s[1], s[2], s[3]
+			expanded := fmt.Sprintf("#%c%c%c%c%c%c", r, r, g, g, b, b)
+			return lipgloss.Color(expanded), nil
+		}
+		return nil, fmt.Errorf("invalid hex color %q: must be #RGB or #RRGGBB", s)
+	}
+
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return nil, fmt.Errorf("invalid color %q: must be hex (#RGB/#RRGGBB) or ANSI number (0-255)", s)
+	}
+	if n < 0 || n > 255 {
+		return nil, fmt.Errorf("invalid ANSI color %d: must be 0-255", n)
+	}
+	return lipgloss.Color(s), nil
+}
 
 // Theme defines the color scheme for the application
 type Theme struct {
@@ -39,41 +84,37 @@ type Theme struct {
 	TableHeader     color.Color // Table header background
 	TableHeaderText color.Color // Table header text
 	TableBorder     color.Color // Table border
+
+	// Badge colors (for READ-ONLY indicator, etc.)
+	BadgeForeground color.Color // Badge text color
+	BadgeBackground color.Color // Badge background color
 }
 
-// DefaultTheme returns the default dark theme
 func DefaultTheme() *Theme {
 	return &Theme{
-		// Primary colors
-		Primary:   lipgloss.Color("170"), // Pink/Magenta
-		Secondary: lipgloss.Color("33"),  // Blue
-		Accent:    lipgloss.Color("86"),  // Cyan
-
-		// Text colors
-		Text:       lipgloss.Color("252"), // Light gray
-		TextBright: lipgloss.Color("255"), // White
-		TextDim:    lipgloss.Color("247"), // Medium gray
-		TextMuted:  lipgloss.Color("244"), // Darker gray
-
-		// Semantic colors
-		Success: lipgloss.Color("42"),  // Green
-		Warning: lipgloss.Color("214"), // Orange
-		Danger:  lipgloss.Color("196"), // Red
-		Info:    lipgloss.Color("33"),  // Blue
-		Pending: lipgloss.Color("226"), // Yellow
-
-		// UI element colors
-		Border:          lipgloss.Color("244"), // Gray border
-		BorderHighlight: lipgloss.Color("170"), // Pink highlight
-		Background:      lipgloss.Color("235"), // Dark background
-		BackgroundAlt:   lipgloss.Color("237"), // Slightly lighter
-		Selection:       lipgloss.Color("57"),  // Purple selection
-		SelectionText:   lipgloss.Color("229"), // Light yellow
-
-		// Table colors
-		TableHeader:     lipgloss.Color("63"),  // Purple header
-		TableHeaderText: lipgloss.Color("229"), // Light yellow
-		TableBorder:     lipgloss.Color("246"), // Gray border
+		Primary:         lipgloss.Color("170"),
+		Secondary:       lipgloss.Color("33"),
+		Accent:          lipgloss.Color("86"),
+		Text:            lipgloss.Color("252"),
+		TextBright:      lipgloss.Color("255"),
+		TextDim:         lipgloss.Color("247"),
+		TextMuted:       lipgloss.Color("244"),
+		Success:         lipgloss.Color("42"),
+		Warning:         lipgloss.Color("214"),
+		Danger:          lipgloss.Color("196"),
+		Info:            lipgloss.Color("33"),
+		Pending:         lipgloss.Color("226"),
+		Border:          lipgloss.Color("244"),
+		BorderHighlight: lipgloss.Color("170"),
+		Background:      lipgloss.Color("235"),
+		BackgroundAlt:   lipgloss.Color("237"),
+		Selection:       lipgloss.Color("57"),
+		SelectionText:   lipgloss.Color("229"),
+		TableHeader:     lipgloss.Color("63"),
+		TableHeaderText: lipgloss.Color("229"),
+		TableBorder:     lipgloss.Color("246"),
+		BadgeForeground: lipgloss.Color("16"),
+		BadgeBackground: lipgloss.Color("214"),
 	}
 }
 
@@ -83,6 +124,54 @@ var current = DefaultTheme()
 // Current returns the current active theme
 func Current() *Theme {
 	return current
+}
+
+func SetTheme(t *Theme) {
+	if t != nil {
+		current = t
+	}
+}
+
+func ApplyConfig(cfg config.ThemeConfig) {
+	theme := DefaultTheme()
+
+	applyColor := func(name string, value string, target *color.Color) {
+		if value == "" {
+			return
+		}
+		c, err := ParseColor(value)
+		if err != nil {
+			slog.Warn("invalid theme color, using default", "field", name, "value", value, "error", err)
+			return
+		}
+		*target = c
+	}
+
+	applyColor("primary", cfg.Primary, &theme.Primary)
+	applyColor("secondary", cfg.Secondary, &theme.Secondary)
+	applyColor("accent", cfg.Accent, &theme.Accent)
+	applyColor("text", cfg.Text, &theme.Text)
+	applyColor("text_bright", cfg.TextBright, &theme.TextBright)
+	applyColor("text_dim", cfg.TextDim, &theme.TextDim)
+	applyColor("text_muted", cfg.TextMuted, &theme.TextMuted)
+	applyColor("success", cfg.Success, &theme.Success)
+	applyColor("warning", cfg.Warning, &theme.Warning)
+	applyColor("danger", cfg.Danger, &theme.Danger)
+	applyColor("info", cfg.Info, &theme.Info)
+	applyColor("pending", cfg.Pending, &theme.Pending)
+	applyColor("border", cfg.Border, &theme.Border)
+	applyColor("border_highlight", cfg.BorderHighlight, &theme.BorderHighlight)
+	applyColor("background", cfg.Background, &theme.Background)
+	applyColor("background_alt", cfg.BackgroundAlt, &theme.BackgroundAlt)
+	applyColor("selection", cfg.Selection, &theme.Selection)
+	applyColor("selection_text", cfg.SelectionText, &theme.SelectionText)
+	applyColor("table_header", cfg.TableHeader, &theme.TableHeader)
+	applyColor("table_header_text", cfg.TableHeaderText, &theme.TableHeaderText)
+	applyColor("table_border", cfg.TableBorder, &theme.TableBorder)
+	applyColor("badge_foreground", cfg.BadgeForeground, &theme.BadgeForeground)
+	applyColor("badge_background", cfg.BadgeBackground, &theme.BadgeBackground)
+
+	SetTheme(theme)
 }
 
 // Style helpers that use the current theme
@@ -213,8 +302,8 @@ func InputFieldStyle() lipgloss.Style {
 // ReadOnlyBadgeStyle returns a style for the READ-ONLY indicator badge
 func ReadOnlyBadgeStyle() lipgloss.Style {
 	return lipgloss.NewStyle().
-		Background(current.Warning).
-		Foreground(lipgloss.Color("#000000")). // TODO: extract to theme in #96
+		Background(current.BadgeBackground).
+		Foreground(current.BadgeForeground).
 		Bold(true).
 		Padding(0, 1)
 }

--- a/internal/ui/theme_test.go
+++ b/internal/ui/theme_test.go
@@ -3,6 +3,8 @@ package ui
 import (
 	"image/color"
 	"testing"
+
+	"github.com/clawscli/claws/internal/config"
 )
 
 func TestDefaultTheme(t *testing.T) {
@@ -285,6 +287,14 @@ func TestInputFieldStyle(t *testing.T) {
 	}
 }
 
+func TestReadOnlyBadgeStyle(t *testing.T) {
+	style := ReadOnlyBadgeStyle()
+	rendered := style.Render("READ-ONLY")
+	if rendered == "" {
+		t.Error("ReadOnlyBadgeStyle().Render() should produce output")
+	}
+}
+
 func TestThemeFields(t *testing.T) {
 	theme := DefaultTheme()
 
@@ -338,5 +348,170 @@ func TestThemeFields(t *testing.T) {
 		if tc.color == nil {
 			t.Errorf("%s color should not be nil", tc.name)
 		}
+	}
+
+	// Test badge colors
+	badgeColors := []struct {
+		name  string
+		color color.Color
+	}{
+		{"BadgeForeground", theme.BadgeForeground},
+		{"BadgeBackground", theme.BadgeBackground},
+	}
+
+	for _, tc := range badgeColors {
+		if tc.color == nil {
+			t.Errorf("%s color should not be nil", tc.name)
+		}
+	}
+}
+
+func TestParseColor(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantNil bool
+		wantErr bool
+	}{
+		{"empty string", "", true, false},
+		{"whitespace only", "   ", true, false},
+		{"valid hex 6", "#ff5733", false, false},
+		{"valid hex 6 upper", "#FF5733", false, false},
+		{"valid hex 3", "#f00", false, false},
+		{"valid hex 3 upper", "#F00", false, false},
+		{"valid ANSI 0", "0", false, false},
+		{"valid ANSI 170", "170", false, false},
+		{"valid ANSI 255", "255", false, false},
+		{"invalid hex short", "#ff", false, true},
+		{"invalid hex long", "#ff57331", false, true},
+		{"invalid hex chars", "#gggggg", false, true},
+		{"invalid ANSI negative", "-1", false, true},
+		{"invalid ANSI over 255", "256", false, true},
+		{"invalid string", "red", false, true},
+		{"invalid mixed", "ff5733", false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := ParseColor(tt.input)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("ParseColor(%q) expected error, got nil", tt.input)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("ParseColor(%q) unexpected error: %v", tt.input, err)
+				return
+			}
+
+			if tt.wantNil && c != nil {
+				t.Errorf("ParseColor(%q) expected nil, got %v", tt.input, c)
+			}
+			if !tt.wantNil && c == nil {
+				t.Errorf("ParseColor(%q) expected color, got nil", tt.input)
+			}
+		})
+	}
+}
+
+func TestParseColorHex3Expansion(t *testing.T) {
+	c, err := ParseColor("#f00")
+	if err != nil {
+		t.Fatalf("ParseColor(#f00) unexpected error: %v", err)
+	}
+	if c == nil {
+		t.Fatal("ParseColor(#f00) returned nil")
+	}
+
+	r, g, b, _ := c.RGBA()
+	if r>>8 != 0xff || g>>8 != 0 || b>>8 != 0 {
+		t.Errorf("ParseColor(#f00) expected red, got R=%d G=%d B=%d", r>>8, g>>8, b>>8)
+	}
+}
+
+func TestSetTheme(t *testing.T) {
+	original := Current()
+
+	newTheme := DefaultTheme()
+	newTheme.Primary = nil
+
+	SetTheme(newTheme)
+	if Current() != newTheme {
+		t.Error("SetTheme did not set the theme")
+	}
+
+	SetTheme(nil)
+	if Current() != newTheme {
+		t.Error("SetTheme(nil) should not change theme")
+	}
+
+	SetTheme(original)
+}
+
+func TestApplyConfig(t *testing.T) {
+	original := Current()
+	defer SetTheme(original)
+
+	cfg := config.ThemeConfig{
+		Primary: "#ff0000",
+		Success: "42",
+		Danger:  "#f00",
+	}
+
+	ApplyConfig(cfg)
+
+	theme := Current()
+
+	r, g, b, _ := theme.Primary.RGBA()
+	if r>>8 != 0xff || g>>8 != 0 || b>>8 != 0 {
+		t.Errorf("Primary expected red, got R=%d G=%d B=%d", r>>8, g>>8, b>>8)
+	}
+
+	if theme.Secondary == nil {
+		t.Error("Secondary should use default, not nil")
+	}
+}
+
+func TestApplyConfigInvalidColor(t *testing.T) {
+	original := Current()
+	defer SetTheme(original)
+
+	defaultTheme := DefaultTheme()
+
+	cfg := config.ThemeConfig{
+		Primary: "invalid",
+		Success: "#gggggg",
+	}
+
+	ApplyConfig(cfg)
+
+	theme := Current()
+
+	if !colorsEqual(theme.Primary, defaultTheme.Primary) {
+		t.Error("Invalid primary should fallback to default")
+	}
+	if !colorsEqual(theme.Success, defaultTheme.Success) {
+		t.Error("Invalid success should fallback to default")
+	}
+}
+
+func TestApplyConfigEmpty(t *testing.T) {
+	original := Current()
+	defer SetTheme(original)
+
+	defaultTheme := DefaultTheme()
+
+	ApplyConfig(config.ThemeConfig{})
+
+	theme := Current()
+
+	if !colorsEqual(theme.Primary, defaultTheme.Primary) {
+		t.Error("Empty config should use default primary")
+	}
+	if !colorsEqual(theme.Success, defaultTheme.Success) {
+		t.Error("Empty config should use default success")
 	}
 }

--- a/internal/view/action_menu.go
+++ b/internal/view/action_menu.go
@@ -37,14 +37,14 @@ func newActionMenuStyles() actionMenuStyles {
 	t := ui.Current()
 	return actionMenuStyles{
 		title:     ui.TitleStyle(),
-		item:      lipgloss.NewStyle().PaddingLeft(2),
+		item:      lipgloss.NewStyle().Foreground(t.Text),
 		selected:  ui.SelectedStyle().PaddingLeft(2),
 		shortcut:  ui.SecondaryStyle(),
 		box:       ui.BoxStyle().MarginTop(1),
 		dangerBox: ui.BoxStyle().BorderForeground(t.Danger).MarginTop(1),
 		yes:       ui.BoldSuccessStyle(),
 		no:        ui.BoldDangerStyle(),
-		bold:      lipgloss.NewStyle().Bold(true),
+		bold:      lipgloss.NewStyle().Bold(true).Foreground(t.Text),
 		input:     ui.InputStyle(),
 	}
 }
@@ -299,13 +299,12 @@ func (m *ActionMenu) ViewString() string {
 	}
 
 	for i, act := range m.actions {
-		style := s.item
+		shortcutText := fmt.Sprintf("[%s]", act.Shortcut)
 		if i == m.cursor {
-			style = s.selected
+			out += s.selected.Render(fmt.Sprintf("%s %s", shortcutText, act.Name)) + "\n"
+		} else {
+			out += fmt.Sprintf("  %s %s", s.shortcut.Render(shortcutText), s.item.Render(act.Name)) + "\n"
 		}
-
-		shortcut := s.shortcut.Render(fmt.Sprintf("[%s]", act.Shortcut))
-		out += style.Render(fmt.Sprintf("%s %s", shortcut, act.Name)) + "\n"
 	}
 
 	if m.dangerous.active && m.confirmIdx < len(m.actions) {

--- a/internal/view/dashboard_view.go
+++ b/internal/view/dashboard_view.go
@@ -21,6 +21,7 @@ type hitArea struct {
 }
 
 type dashboardStyles struct {
+	text      lipgloss.Style
 	warning   lipgloss.Style
 	danger    lipgloss.Style
 	success   lipgloss.Style
@@ -30,6 +31,7 @@ type dashboardStyles struct {
 
 func newDashboardStyles() dashboardStyles {
 	return dashboardStyles{
+		text:      ui.TextStyle(),
 		warning:   ui.WarningStyle(),
 		danger:    ui.DangerStyle(),
 		success:   ui.SuccessStyle(),

--- a/internal/view/dashboard_view_panels.go
+++ b/internal/view/dashboard_view_panels.go
@@ -78,11 +78,11 @@ func (d *DashboardView) renderCostContent(contentWidth, contentHeight int, t *ui
 	var lines []string
 
 	if d.costLoading {
-		lines = append(lines, d.spinner.View()+" loading...")
+		lines = append(lines, s.text.Render(d.spinner.View()+" loading..."))
 	} else if d.costErr != nil {
 		lines = append(lines, s.dim.Render("Cost: N/A"))
 	} else {
-		lines = append(lines, "MTD: "+appaws.FormatMoney(d.costMTD, ""))
+		lines = append(lines, s.text.Render("MTD: "+appaws.FormatMoney(d.costMTD, "")))
 
 		if len(d.costTop) > 0 {
 			maxCost := d.costTop[0].cost
@@ -101,19 +101,21 @@ func (d *DashboardView) renderCostContent(contentWidth, contentHeight int, t *ui
 				line := fmt.Sprintf("%-*s %s %8.0f", nameWidth, name, bar, c.cost)
 				if i == focusRow {
 					line = s.highlight.Render(line)
+				} else {
+					line = s.text.Render(line)
 				}
 				lines = append(lines, line)
 			}
 		}
 
 		if d.anomalyLoading {
-			lines = append(lines, "Anomalies: "+d.spinner.View())
+			lines = append(lines, s.text.Render("Anomalies: "+d.spinner.View()))
 		} else if d.anomalyErr != nil {
-			lines = append(lines, "Anomalies: "+s.dim.Render("N/A"))
+			lines = append(lines, s.text.Render("Anomalies: ")+s.dim.Render("N/A"))
 		} else if d.anomalyCount > 0 {
-			lines = append(lines, "Anomalies: "+s.warning.Render(fmt.Sprintf("%d", d.anomalyCount)))
+			lines = append(lines, s.text.Render("Anomalies: ")+s.warning.Render(fmt.Sprintf("%d", d.anomalyCount)))
 		} else {
-			lines = append(lines, "Anomalies: "+s.success.Render("0"))
+			lines = append(lines, s.text.Render("Anomalies: ")+s.success.Render("0"))
 		}
 	}
 
@@ -126,25 +128,25 @@ func (d *DashboardView) renderOpsContent(contentWidth, contentHeight int, focusR
 	alarmCount := len(d.alarms)
 
 	if d.alarmLoading {
-		lines = append(lines, "Alarms: "+d.spinner.View())
+		lines = append(lines, s.text.Render("Alarms: "+d.spinner.View()))
 	} else if d.alarmErr != nil {
 		lines = append(lines, s.dim.Render("Alarms: N/A"))
 	} else if alarmCount > 0 {
 		lines = append(lines, s.danger.Render(fmt.Sprintf("Alarms: %d in ALARM", alarmCount)))
 		maxShow := min(alarmCount, contentHeight-3)
 		for i := range maxShow {
-			line := "  " + s.danger.Render("• ") + TruncateString(d.alarms[i].name, contentWidth-bulletIndentWidth)
+			line := "  " + s.danger.Render("• ") + s.text.Render(TruncateString(d.alarms[i].name, contentWidth-bulletIndentWidth))
 			if i == focusRow {
 				line = s.highlight.Render(line)
 			}
 			lines = append(lines, line)
 		}
 	} else {
-		lines = append(lines, "Alarms: "+s.success.Render("0 ✓"))
+		lines = append(lines, s.text.Render("Alarms: ")+s.success.Render("0 ✓"))
 	}
 
 	if d.healthLoading {
-		lines = append(lines, "Health: "+d.spinner.View())
+		lines = append(lines, s.text.Render("Health: "+d.spinner.View()))
 	} else if d.healthErr != nil {
 		lines = append(lines, s.dim.Render("Health: N/A"))
 	} else if len(d.healthItems) > 0 {
@@ -153,14 +155,14 @@ func (d *DashboardView) renderOpsContent(contentWidth, contentHeight int, focusR
 		maxShow := min(len(d.healthItems), remaining)
 		for i := range maxShow {
 			h := d.healthItems[i]
-			line := "  " + s.warning.Render("• ") + TruncateString(h.service+": "+h.eventType, contentWidth-bulletIndentWidth)
+			line := "  " + s.warning.Render("• ") + s.text.Render(TruncateString(h.service+": "+h.eventType, contentWidth-bulletIndentWidth))
 			if alarmCount+i == focusRow {
 				line = s.highlight.Render(line)
 			}
 			lines = append(lines, line)
 		}
 	} else {
-		lines = append(lines, "Health: "+s.success.Render("0 open ✓"))
+		lines = append(lines, s.text.Render("Health: ")+s.success.Render("0 open ✓"))
 	}
 
 	return strings.Join(lines, "\n")
@@ -171,7 +173,7 @@ func (d *DashboardView) renderSecurityContent(contentWidth, contentHeight int, f
 	var lines []string
 
 	if d.secLoading {
-		lines = append(lines, d.spinner.View()+" loading...")
+		lines = append(lines, s.text.Render(d.spinner.View()+" loading..."))
 	} else if d.secErr != nil {
 		lines = append(lines, s.dim.Render("Security: N/A"))
 	} else if len(d.secItems) > 0 {
@@ -196,7 +198,7 @@ func (d *DashboardView) renderSecurityContent(contentWidth, contentHeight int, f
 			if item.severity == "CRITICAL" {
 				style = s.danger
 			}
-			line := "  " + style.Render("• ") + TruncateString(item.title, contentWidth-bulletIndentWidth)
+			line := "  " + style.Render("• ") + s.text.Render(TruncateString(item.title, contentWidth-bulletIndentWidth))
 			if i == focusRow {
 				line = s.highlight.Render(line)
 			}
@@ -214,7 +216,7 @@ func (d *DashboardView) renderOptimizationContent(contentWidth, contentHeight in
 	var lines []string
 
 	if d.taLoading {
-		lines = append(lines, d.spinner.View()+" loading...")
+		lines = append(lines, s.text.Render(d.spinner.View()+" loading..."))
 	} else if d.taErr != nil {
 		lines = append(lines, s.dim.Render("Optimization: N/A"))
 	} else {
@@ -243,7 +245,7 @@ func (d *DashboardView) renderOptimizationContent(contentWidth, contentHeight in
 				if item.status == "error" {
 					style = s.danger
 				}
-				line := "  " + style.Render("• ") + TruncateString(item.name, contentWidth-bulletIndentWidth)
+				line := "  " + style.Render("• ") + s.text.Render(TruncateString(item.name, contentWidth-bulletIndentWidth))
 				if i == focusRow {
 					line = s.highlight.Render(line)
 				}

--- a/internal/view/multi_selector.go
+++ b/internal/view/multi_selector.go
@@ -24,9 +24,10 @@ type selectorStyles struct {
 }
 
 func newSelectorStyles() selectorStyles {
+	t := ui.Current()
 	return selectorStyles{
 		title:        ui.TableHeaderStyle().Padding(0, 1),
-		item:         lipgloss.NewStyle().PaddingLeft(2),
+		item:         lipgloss.NewStyle().Foreground(t.Text).PaddingLeft(2),
 		itemSelected: ui.SelectedStyle().PaddingLeft(2),
 		itemChecked:  ui.SuccessStyle().PaddingLeft(2),
 		filter:       ui.AccentStyle(),

--- a/internal/view/resource_browser.go
+++ b/internal/view/resource_browser.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"charm.land/bubbles/v2/spinner"
-	"charm.land/bubbles/v2/table"
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
@@ -63,15 +62,18 @@ type ResourceBrowser struct {
 
 	// Tab positions for mouse click detection
 	tabPositions []tabPosition
-	table        table.Model
-	dao          dao.DAO
-	renderer     render.Renderer
-	resources    []dao.Resource
-	filtered     []dao.Resource
-	loading      bool
-	err          error
-	width        int
-	height       int
+
+	tc           TableCursor
+	tableContent string
+
+	dao       dao.DAO
+	renderer  render.Renderer
+	resources []dao.Resource
+	filtered  []dao.Resource
+	loading   bool
+	err       error
+	width     int
+	height    int
 
 	// Header panel
 	headerPanel *HeaderPanel
@@ -247,16 +249,13 @@ func (r *ResourceBrowser) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 
-	var cmd tea.Cmd
-	r.table, cmd = r.table.Update(msg)
-
 	// Check if we should load more pages (infinite scroll)
 	if r.shouldLoadNextPage() {
 		r.isLoadingMore = true
-		return r, tea.Batch(cmd, r.loadNextPage)
+		return r, r.loadNextPage
 	}
 
-	return r, cmd
+	return r, nil
 }
 
 // ViewString returns the view content as a string
@@ -271,10 +270,9 @@ func (r *ResourceBrowser) ViewString() string {
 		return header + "\n" + ui.DangerStyle().Render(fmt.Sprintf("Error: %v", r.err))
 	}
 
-	// Get selected resource summary fields
 	var summaryFields []render.SummaryField
-	if len(r.filtered) > 0 && r.table.Cursor() < len(r.filtered) && r.renderer != nil {
-		selectedResource := dao.UnwrapResource(r.filtered[r.table.Cursor()])
+	if len(r.filtered) > 0 && r.tc.Cursor() < len(r.filtered) && r.renderer != nil {
+		selectedResource := dao.UnwrapResource(r.filtered[r.tc.Cursor()])
 		summaryFields = r.renderer.RenderSummary(selectedResource)
 	}
 
@@ -314,7 +312,7 @@ func (r *ResourceBrowser) ViewString() string {
 			ui.DimStyle().Render("No resources found")
 	}
 
-	return headerPanel + "\n" + tabsView + "\n" + filterView + r.table.View()
+	return headerPanel + "\n" + tabsView + "\n" + filterView + r.tableContent
 }
 
 // View implements tea.Model

--- a/internal/view/resource_browser_fetch.go
+++ b/internal/view/resource_browser_fetch.go
@@ -385,7 +385,7 @@ func (r *ResourceBrowser) shouldLoadNextPage() bool {
 		return false
 	}
 	buffer := 10
-	return r.table.Cursor() >= len(r.filtered)-buffer
+	return r.tc.Cursor() >= len(r.filtered)-buffer
 }
 
 func (r *ResourceBrowser) loadNextPage() tea.Msg {

--- a/internal/view/resource_browser_nav.go
+++ b/internal/view/resource_browser_nav.go
@@ -16,7 +16,7 @@ func (r *ResourceBrowser) handleNavigation(key string) (tea.Model, tea.Cmd) {
 		return nil, nil
 	}
 
-	ctx, resource := r.contextForResource(r.filtered[r.table.Cursor()])
+	ctx, resource := r.contextForResource(r.filtered[r.tc.Cursor()])
 
 	helper := &NavigationHelper{
 		Ctx:      ctx,
@@ -168,6 +168,6 @@ func (r *ResourceBrowser) getNavigationShortcuts() string {
 	}
 
 	helper := &NavigationHelper{Renderer: r.renderer}
-	resource := dao.UnwrapResource(r.filtered[r.table.Cursor()])
+	resource := dao.UnwrapResource(r.filtered[r.tc.Cursor()])
 	return helper.FormatShortcuts(resource)
 }

--- a/internal/view/resource_browser_table.go
+++ b/internal/view/resource_browser_table.go
@@ -1,8 +1,8 @@
 package view
 
 import (
-	"charm.land/bubbles/v2/table"
 	"charm.land/lipgloss/v2"
+	"charm.land/lipgloss/v2/table"
 
 	"github.com/clawscli/claws/internal/config"
 	"github.com/clawscli/claws/internal/dao"
@@ -11,19 +11,34 @@ import (
 	"github.com/clawscli/claws/internal/ui"
 )
 
+const (
+	markColWidth    = 3
+	profileColWidth = 16
+	accountColWidth = 14
+	regionColWidth  = 14
+)
+
+func (r *ResourceBrowser) Cursor() int {
+	return r.tc.Cursor()
+}
+
+func (r *ResourceBrowser) SetCursor(n int) {
+	r.tc.SetCursor(n, len(r.filtered))
+}
+
 func (r *ResourceBrowser) buildTable() {
 	if r.renderer == nil {
+		r.tableContent = ""
 		return
 	}
 
-	currentCursor := r.table.Cursor()
-	cols := r.renderer.Columns()
+	r.tc.SetCursor(r.tc.Cursor(), len(r.filtered))
 
-	const markColWidth = 2
-	const profileColWidth = 16
-	const accountColWidth = 14
-	const regionColWidth = 14
-	metricsColWidth := metrics.ColumnWidth
+	cols := r.renderer.Columns()
+	if len(cols) == 0 {
+		r.tableContent = ""
+		return
+	}
 
 	effectiveMetricsEnabled := r.metricsEnabled && r.getMetricSpec() != nil
 	isMultiProfile := config.Global().IsMultiProfile()
@@ -38,59 +53,24 @@ func (r *ResourceBrowser) buildTable() {
 	if effectiveMetricsEnabled {
 		numCols++
 	}
-	tableCols := make([]table.Column, numCols)
-	tableCols[0] = table.Column{Title: " ", Width: markColWidth}
 
-	totalColWidth := markColWidth
-	for _, col := range cols {
-		totalColWidth += col.Width
-	}
-	if isMultiProfile {
-		totalColWidth += profileColWidth + accountColWidth + regionColWidth
-	} else if isMultiRegion {
-		totalColWidth += regionColWidth
-	}
-	if effectiveMetricsEnabled {
-		totalColWidth += metricsColWidth
-	}
-
-	extraWidth := r.width - totalColWidth
-	if extraWidth < 0 {
-		extraWidth = 0
-	}
-
-	hasTrailingCols := isMultiProfile || isMultiRegion || effectiveMetricsEnabled
+	headers := make([]string, numCols)
+	headers[0] = ""
 	colIdx := 1
 	for i, col := range cols {
-		title := col.Name + r.getSortIndicator(i)
-		width := col.Width
-		if i == len(cols)-1 && !hasTrailingCols {
-			width += extraWidth
-		}
-		tableCols[colIdx] = table.Column{
-			Title: title,
-			Width: width,
-		}
+		headers[colIdx] = col.Name + r.getSortIndicator(i)
 		colIdx++
 	}
 
 	if isMultiProfile {
-		tableCols[colIdx] = table.Column{Title: "PROFILE", Width: profileColWidth}
+		headers[colIdx] = "PROFILE"
 		colIdx++
-		tableCols[colIdx] = table.Column{Title: "ACCOUNT", Width: accountColWidth}
+		headers[colIdx] = "ACCOUNT"
 		colIdx++
-		width := regionColWidth
-		if !effectiveMetricsEnabled {
-			width += extraWidth
-		}
-		tableCols[colIdx] = table.Column{Title: "REGION", Width: width}
+		headers[colIdx] = "REGION"
 		colIdx++
 	} else if isMultiRegion {
-		width := regionColWidth
-		if !effectiveMetricsEnabled {
-			width += extraWidth
-		}
-		tableCols[colIdx] = table.Column{Title: "REGION", Width: width}
+		headers[colIdx] = "REGION"
 		colIdx++
 	}
 
@@ -100,21 +80,69 @@ func (r *ResourceBrowser) buildTable() {
 		if spec != nil {
 			header = spec.ColumnHeader
 		}
-		tableCols[colIdx] = table.Column{
-			Title: header,
-			Width: metricsColWidth + extraWidth,
-		}
+		headers[colIdx] = header
 	}
 
-	rows := make([]table.Row, len(r.filtered))
-	for i, res := range r.filtered {
+	var summaryFields []render.SummaryField
+	cursor := r.tc.Cursor()
+	if len(r.filtered) > 0 && cursor >= 0 && cursor < len(r.filtered) {
+		summaryFields = r.renderer.RenderSummary(dao.UnwrapResource(r.filtered[cursor]))
+	}
+	headerStr := r.headerPanel.Render(r.service, r.resourceType, summaryFields)
+	headerHeight := r.headerPanel.Height(headerStr)
+
+	tableHeight := r.height - headerHeight - 1
+	if tableHeight < 1 {
+		tableHeight = 1
+	}
+	r.tc.SetTableHeight(tableHeight)
+
+	th := ui.Current()
+
+	widths := r.calculateColumnWidths(cols, isMultiProfile, isMultiRegion, effectiveMetricsEnabled, numCols)
+
+	t := table.New().
+		Headers(headers...).
+		Width(r.width).
+		Height(tableHeight).
+		Wrap(false).
+		BorderTop(false).
+		BorderBottom(false).
+		BorderLeft(false).
+		BorderRight(false).
+		BorderColumn(false).
+		BorderHeader(true).
+		BorderStyle(lipgloss.NewStyle().Foreground(th.TableBorder)).
+		StyleFunc(func(row, col int) lipgloss.Style {
+			w := 0
+			if col < len(widths) {
+				w = widths[col]
+			}
+			s := lipgloss.NewStyle().Width(w)
+			if col == 0 {
+				s = s.PaddingLeft(1)
+			}
+			if row == table.HeaderRow {
+				return s.Bold(true).
+					Foreground(th.TableHeaderText).
+					Background(th.TableHeader)
+			}
+			if row == cursor {
+				return s.Foreground(th.SelectionText).
+					Background(th.Selection)
+			}
+			return s.Foreground(th.Text)
+		})
+
+	for _, res := range r.filtered {
 		row := r.renderer.RenderRow(dao.UnwrapResource(res), cols)
-		markIndicator := "  "
+		mark := " "
 		if r.markedResource != nil && r.markedResource.GetID() == res.GetID() {
-			markIndicator = "◆ "
+			mark = "◆"
 		}
-		fullRow := make(table.Row, numCols)
-		fullRow[0] = markIndicator
+
+		fullRow := make([]string, numCols)
+		fullRow[0] = mark
 		copy(fullRow[1:], row)
 
 		rowIdx := len(cols) + 1
@@ -139,57 +167,75 @@ func (r *ResourceBrowser) buildTable() {
 		} else if effectiveMetricsEnabled {
 			fullRow[rowIdx] = metrics.RenderSparkline(nil, "")
 		}
-		rows[i] = fullRow
+
+		t = t.Row(fullRow...)
 	}
 
-	// Calculate header height dynamically
-	var summaryFields []render.SummaryField
-	if len(r.filtered) > 0 && currentCursor >= 0 && currentCursor < len(r.filtered) {
-		summaryFields = r.renderer.RenderSummary(dao.UnwrapResource(r.filtered[currentCursor]))
-	}
-	headerStr := r.headerPanel.Render(r.service, r.resourceType, summaryFields)
-	headerHeight := r.headerPanel.Height(headerStr)
-
-	// height - header - tabs(1)
-	tableHeight := r.height - headerHeight - 1
-	if tableHeight < 5 {
-		tableHeight = 5
+	if r.tc.ScrollOffset() > 0 {
+		t = t.YOffset(r.tc.ScrollOffset())
 	}
 
-	t := table.New(
-		table.WithColumns(tableCols),
-		table.WithRows(rows),
-		table.WithFocused(true),
-		table.WithHeight(tableHeight),
-		table.WithWidth(r.width),
-	)
+	r.tableContent = t.String()
+}
 
-	th := ui.Current()
-	s := table.DefaultStyles()
-	s.Header = s.Header.
-		BorderStyle(lipgloss.NormalBorder()).
-		BorderForeground(th.TableBorder).
-		BorderBottom(true).
-		Bold(true).
-		Foreground(th.TableHeaderText).
-		Background(th.TableHeader)
-	s.Selected = s.Selected.
-		Foreground(th.SelectionText).
-		Background(th.Selection).
-		Bold(false)
-	// Note: Not setting s.Cell foreground - let Selected style take precedence
-	t.SetStyles(s)
+func (r *ResourceBrowser) calculateColumnWidths(cols []render.Column, isMultiProfile, isMultiRegion, hasMetrics bool, numCols int) []int {
+	metricsColWidth := metrics.ColumnWidth
 
-	// Restore cursor position (clamped to valid range)
-	if len(rows) > 0 {
-		if currentCursor >= len(rows) {
-			currentCursor = len(rows) - 1
+	totalColWidth := markColWidth
+	for _, col := range cols {
+		totalColWidth += col.Width
+	}
+	if isMultiProfile {
+		totalColWidth += profileColWidth + accountColWidth + regionColWidth
+	} else if isMultiRegion {
+		totalColWidth += regionColWidth
+	}
+	if hasMetrics {
+		totalColWidth += metricsColWidth
+	}
+
+	extraWidth := r.width - totalColWidth
+	if extraWidth < 0 {
+		extraWidth = 0
+	}
+
+	hasTrailingCols := isMultiProfile || isMultiRegion || hasMetrics
+	widths := make([]int, numCols)
+	widths[0] = markColWidth
+
+	colIdx := 1
+	for i, col := range cols {
+		w := col.Width
+		if i == len(cols)-1 && !hasTrailingCols {
+			w += extraWidth
 		}
-		if currentCursor < 0 {
-			currentCursor = 0
-		}
-		t.SetCursor(currentCursor)
+		widths[colIdx] = w
+		colIdx++
 	}
 
-	r.table = t
+	if isMultiProfile {
+		widths[colIdx] = profileColWidth
+		colIdx++
+		widths[colIdx] = accountColWidth
+		colIdx++
+		w := regionColWidth
+		if !hasMetrics {
+			w += extraWidth
+		}
+		widths[colIdx] = w
+		colIdx++
+	} else if isMultiRegion {
+		w := regionColWidth
+		if !hasMetrics {
+			w += extraWidth
+		}
+		widths[colIdx] = w
+		colIdx++
+	}
+
+	if hasMetrics {
+		widths[colIdx] = metricsColWidth + extraWidth
+	}
+
+	return widths
 }

--- a/internal/view/resource_browser_test.go
+++ b/internal/view/resource_browser_test.go
@@ -158,13 +158,13 @@ func TestResourceBrowserMouseHover(t *testing.T) {
 	browser.applyFilter()
 	browser.buildTable()
 
-	initialCursor := browser.table.Cursor()
+	initialCursor := browser.Cursor()
 
 	// Simulate mouse motion
 	motionMsg := tea.MouseMotionMsg{X: 30, Y: 10}
 	browser.Update(motionMsg)
 
-	t.Logf("Cursor after hover: %d (was %d)", browser.table.Cursor(), initialCursor)
+	t.Logf("Cursor after hover: %d (was %d)", browser.Cursor(), initialCursor)
 }
 
 func TestResourceBrowserMouseClick(t *testing.T) {
@@ -210,7 +210,7 @@ func TestResourceBrowserMarkUnmark(t *testing.T) {
 	}
 
 	// Mark first resource
-	browser.table.SetCursor(0)
+	browser.SetCursor(0)
 	mMsg := tea.KeyPressMsg{Code: 'm'}
 	browser.Update(mMsg)
 
@@ -229,9 +229,9 @@ func TestResourceBrowserMarkUnmark(t *testing.T) {
 	}
 
 	// Mark first, then mark second (should replace)
-	browser.table.SetCursor(0)
+	browser.SetCursor(0)
 	browser.Update(mMsg)
-	browser.table.SetCursor(1)
+	browser.SetCursor(1)
 	browser.Update(mMsg)
 
 	if browser.markedResource == nil {
@@ -259,7 +259,7 @@ func TestResourceBrowserMarkClearedOnResourceTypeSwitch(t *testing.T) {
 	browser.applyFilter()
 	browser.buildTable()
 
-	browser.table.SetCursor(0)
+	browser.SetCursor(0)
 	mMsg := tea.KeyPressMsg{Code: 'm'}
 	browser.Update(mMsg)
 
@@ -281,7 +281,7 @@ func TestResourceBrowserMarkClearedOnResourceTypeSwitch(t *testing.T) {
 	}
 	browser.applyFilter()
 	browser.buildTable()
-	browser.table.SetCursor(0)
+	browser.SetCursor(0)
 	browser.Update(mMsg)
 
 	if browser.markedResource == nil {
@@ -314,7 +314,7 @@ func TestResourceBrowserMarkClearedOnFilter(t *testing.T) {
 	browser.buildTable()
 
 	// Mark the first resource
-	browser.table.SetCursor(0)
+	browser.SetCursor(0)
 	mMsg := tea.KeyPressMsg{Code: 'm'}
 	browser.Update(mMsg)
 
@@ -358,7 +358,7 @@ func TestResourceBrowserDiffHintVisibility(t *testing.T) {
 	}
 
 	// Mark a resource: should show "d:diff"
-	browser.table.SetCursor(0)
+	browser.SetCursor(0)
 	mMsg := tea.KeyPressMsg{Code: 'm'}
 	browser.Update(mMsg)
 
@@ -389,7 +389,7 @@ func TestResourceBrowserMarkColumnRendering(t *testing.T) {
 		t.Error("Expected non-empty view")
 	}
 
-	browser.table.SetCursor(0)
+	browser.SetCursor(0)
 	mMsg := tea.KeyPressMsg{Code: 'm'}
 	browser.Update(mMsg)
 
@@ -414,7 +414,7 @@ func TestResourceBrowserEscClearsMark(t *testing.T) {
 	browser.buildTable()
 
 	// Mark a resource
-	browser.table.SetCursor(0)
+	browser.SetCursor(0)
 	mMsg := tea.KeyPressMsg{Code: 'm'}
 	browser.Update(mMsg)
 
@@ -450,14 +450,14 @@ func TestResourceBrowserDiffNavigation(t *testing.T) {
 	browser.applyFilter()
 	browser.buildTable()
 
-	browser.table.SetCursor(0)
+	browser.SetCursor(0)
 	browser.Update(tea.KeyPressMsg{Code: 'm'})
 
 	if browser.markedResource == nil {
 		t.Fatal("Expected resource to be marked")
 	}
 
-	browser.table.SetCursor(1)
+	browser.SetCursor(1)
 	_, cmd := browser.Update(tea.KeyPressMsg{Code: 'd'})
 
 	if cmd == nil {
@@ -619,7 +619,7 @@ func TestResourceBrowserCopyID(t *testing.T) {
 	}
 	browser.applyFilter()
 	browser.buildTable()
-	browser.table.SetCursor(0)
+	browser.SetCursor(0)
 
 	_, cmd := browser.Update(tea.KeyPressMsg{Code: 'y'})
 	if cmd == nil {
@@ -645,7 +645,7 @@ func TestResourceBrowserCopyARN(t *testing.T) {
 	}
 	browser.applyFilter()
 	browser.buildTable()
-	browser.table.SetCursor(0)
+	browser.SetCursor(0)
 
 	_, cmd := browser.Update(tea.KeyPressMsg{Code: 'Y'})
 	if cmd == nil {
@@ -666,7 +666,7 @@ func TestResourceBrowserCopyARNNoARN(t *testing.T) {
 	}
 	browser.applyFilter()
 	browser.buildTable()
-	browser.table.SetCursor(0)
+	browser.SetCursor(0)
 
 	_, cmd := browser.Update(tea.KeyPressMsg{Code: 'Y'})
 	if cmd == nil {

--- a/internal/view/resource_browser_update.go
+++ b/internal/view/resource_browser_update.go
@@ -129,8 +129,8 @@ func (r *ResourceBrowser) handleDiffMsg(msg DiffMsg) (tea.Model, tea.Cmd) {
 	}
 
 	if msg.LeftName == "" {
-		if len(r.filtered) > 0 && r.table.Cursor() < len(r.filtered) {
-			leftRes = r.filtered[r.table.Cursor()]
+		if len(r.filtered) > 0 && r.tc.Cursor() < len(r.filtered) {
+			leftRes = r.filtered[r.tc.Cursor()]
 		}
 	} else {
 		for _, res := range r.filtered {

--- a/internal/view/service_browser.go
+++ b/internal/view/service_browser.go
@@ -83,12 +83,14 @@ type serviceBrowserStyles struct {
 }
 
 func newServiceBrowserStyles() serviceBrowserStyles {
+	t := ui.Current()
 	return serviceBrowserStyles{
 		category: ui.DimStyle().
 			Bold(true).
 			MarginTop(1).
 			MarginBottom(0),
 		cell: lipgloss.NewStyle().
+			Foreground(t.Text).
 			Width(cellWidth).
 			Height(cellHeight).
 			Padding(0, 1),

--- a/internal/view/table_cursor.go
+++ b/internal/view/table_cursor.go
@@ -1,0 +1,85 @@
+package view
+
+// TableCursor manages cursor position and scroll offset for table-based views.
+// Embed this struct in views that display scrollable tables.
+type TableCursor struct {
+	cursor       int
+	scrollOffset int
+	tableHeight  int
+}
+
+// Cursor returns the current cursor position.
+func (c *TableCursor) Cursor() int {
+	return c.cursor
+}
+
+// SetCursor sets the cursor position, clamping to valid range [0, dataLen-1].
+func (c *TableCursor) SetCursor(n int, dataLen int) {
+	if dataLen == 0 {
+		c.cursor = 0
+		return
+	}
+	if n < 0 {
+		n = 0
+	}
+	if n >= dataLen {
+		n = dataLen - 1
+	}
+	c.cursor = n
+}
+
+// ScrollOffset returns the current scroll offset.
+func (c *TableCursor) ScrollOffset() int {
+	return c.scrollOffset
+}
+
+// TableHeight returns the current table height.
+func (c *TableCursor) TableHeight() int {
+	return c.tableHeight
+}
+
+// SetTableHeight sets the table height.
+func (c *TableCursor) SetTableHeight(h int) {
+	c.tableHeight = h
+}
+
+// UpdateScrollOffset adjusts scroll offset to keep cursor visible.
+func (c *TableCursor) UpdateScrollOffset(dataLen int) {
+	visibleRows := c.tableHeight - 2
+	if visibleRows < 1 {
+		visibleRows = 1
+	}
+
+	if c.cursor < c.scrollOffset {
+		c.scrollOffset = c.cursor
+	} else if c.cursor >= c.scrollOffset+visibleRows {
+		c.scrollOffset = c.cursor - visibleRows + 1
+	}
+
+	c.clampScrollOffset(dataLen, visibleRows)
+}
+
+// AdjustScrollOffset adjusts scroll offset by delta (for mouse wheel).
+// Returns the new scroll offset.
+func (c *TableCursor) AdjustScrollOffset(delta int, dataLen int) {
+	visibleRows := c.tableHeight - 2
+	if visibleRows < 1 {
+		visibleRows = 1
+	}
+
+	c.scrollOffset += delta
+	c.clampScrollOffset(dataLen, visibleRows)
+}
+
+func (c *TableCursor) clampScrollOffset(dataLen int, visibleRows int) {
+	maxOffset := dataLen - visibleRows
+	if maxOffset < 0 {
+		maxOffset = 0
+	}
+	if c.scrollOffset > maxOffset {
+		c.scrollOffset = maxOffset
+	}
+	if c.scrollOffset < 0 {
+		c.scrollOffset = 0
+	}
+}

--- a/internal/view/tag_search_view.go
+++ b/internal/view/tag_search_view.go
@@ -9,10 +9,10 @@ import (
 	"sync"
 
 	"charm.land/bubbles/v2/spinner"
-	"charm.land/bubbles/v2/table"
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"charm.land/lipgloss/v2/table"
 	"github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi"
 	tagtypes "github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi/types"
 
@@ -55,7 +55,9 @@ type TagSearchView struct {
 	tagFilter string
 	styles    tagSearchViewStyles
 
-	table     table.Model
+	tc           TableCursor
+	tableContent string
+
 	resources []taggedARN
 	filtered  []taggedARN
 	loading   bool
@@ -295,20 +297,29 @@ func (v *TagSearchView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return v, nil
 
 	case tea.MouseWheelMsg:
-		var cmd tea.Cmd
-		v.table, cmd = v.table.Update(msg)
-		return v, cmd
+		delta := 0
+		switch msg.Button {
+		case tea.MouseWheelUp:
+			delta = -3
+		case tea.MouseWheelDown:
+			delta = 3
+		}
+		v.tc.AdjustScrollOffset(delta, len(v.filtered))
+		v.buildTable()
+		return v, nil
 
 	case tea.MouseMotionMsg:
-		if idx := v.getRowAtPosition(msg.Y); idx >= 0 && idx != v.table.Cursor() {
-			v.table.SetCursor(idx)
+		if idx := v.getRowAtPosition(msg.Y); idx >= 0 && idx != v.tc.Cursor() {
+			v.tc.SetCursor(idx, len(v.filtered))
+			v.buildTable()
 		}
 		return v, nil
 
 	case tea.MouseClickMsg:
 		if msg.Button == tea.MouseLeft && len(v.filtered) > 0 {
 			if idx := v.getRowAtPosition(msg.Y); idx >= 0 {
-				v.table.SetCursor(idx)
+				v.tc.SetCursor(idx, len(v.filtered))
+				v.buildTable()
 				return v.navigateToResource()
 			}
 		}
@@ -365,23 +376,49 @@ func (v *TagSearchView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 		case "enter", "d":
-			if len(v.filtered) > 0 && v.table.Cursor() < len(v.filtered) {
+			if len(v.filtered) > 0 && v.tc.Cursor() < len(v.filtered) {
 				return v.navigateToResource()
 			}
 
 		case "j", "down":
-			v.table.MoveDown(1)
+			v.tc.SetCursor(v.tc.Cursor()+1, len(v.filtered))
+			v.tc.UpdateScrollOffset(len(v.filtered))
+			v.buildTable()
 			return v, nil
 
 		case "k", "up":
-			v.table.MoveUp(1)
+			v.tc.SetCursor(v.tc.Cursor()-1, len(v.filtered))
+			v.tc.UpdateScrollOffset(len(v.filtered))
+			v.buildTable()
+			return v, nil
+
+		case "ctrl+d", "pgdown":
+			v.tc.SetCursor(v.tc.Cursor()+v.tc.TableHeight()/2, len(v.filtered))
+			v.tc.UpdateScrollOffset(len(v.filtered))
+			v.buildTable()
+			return v, nil
+
+		case "ctrl+u", "pgup":
+			v.tc.SetCursor(v.tc.Cursor()-v.tc.TableHeight()/2, len(v.filtered))
+			v.tc.UpdateScrollOffset(len(v.filtered))
+			v.buildTable()
+			return v, nil
+
+		case "g", "home":
+			v.tc.SetCursor(0, len(v.filtered))
+			v.tc.UpdateScrollOffset(len(v.filtered))
+			v.buildTable()
+			return v, nil
+
+		case "G", "end":
+			v.tc.SetCursor(len(v.filtered)-1, len(v.filtered))
+			v.tc.UpdateScrollOffset(len(v.filtered))
+			v.buildTable()
 			return v, nil
 		}
 	}
 
-	var cmd tea.Cmd
-	v.table, cmd = v.table.Update(msg)
-	return v, cmd
+	return v, nil
 }
 
 func (v *TagSearchView) loadNextPage() tea.Msg {
@@ -399,11 +436,12 @@ func (v *TagSearchView) loadNextPage() tea.Msg {
 }
 
 func (v *TagSearchView) navigateToResource() (tea.Model, tea.Cmd) {
-	if len(v.filtered) == 0 || v.table.Cursor() >= len(v.filtered) {
+	cursor := v.tc.Cursor()
+	if len(v.filtered) == 0 || cursor >= len(v.filtered) {
 		return v, nil
 	}
 
-	res := v.filtered[v.table.Cursor()]
+	res := v.filtered[cursor]
 	if res.ARN == nil || !res.ARN.CanNavigate() {
 		return v, nil
 	}
@@ -454,9 +492,6 @@ func (v *TagSearchView) getResourceIDForGet(arn *aws.ARN) string {
 	case "states":
 		return arn.Raw
 	case "bedrock-agentcore":
-		// ARN: arn:aws:bedrock-agentcore:region:account:runtime/RUNTIME_ID/runtime-endpoint/DEFAULT
-		// Extract just the runtime ID (first segment) for GetAgentRuntime API
-		// idx > 0 (not >= 0): if "/" is at position 0, the prefix would be empty string which is invalid
 		if idx := strings.Index(arn.ResourceID, "/"); idx > 0 {
 			return arn.ResourceID[:idx]
 		}
@@ -503,21 +538,84 @@ func (v *TagSearchView) applyFilter() {
 	}
 }
 
+func (v *TagSearchView) Cursor() int {
+	return v.tc.Cursor()
+}
+
+func (v *TagSearchView) SetCursor(n int) {
+	v.tc.SetCursor(n, len(v.filtered))
+}
+
 func (v *TagSearchView) buildTable() {
+	v.tc.SetCursor(v.tc.Cursor(), len(v.filtered))
+
 	isMultiRegion := config.Global().IsMultiRegion()
 
-	columns := []table.Column{
-		{Title: "Service", Width: 12},
-		{Title: "Type", Width: 15},
-		{Title: "ID", Width: 30},
-	}
+	headers := []string{"Service", "Type", "ID"}
 	if isMultiRegion {
-		columns = append(columns, table.Column{Title: "Region", Width: 14})
+		headers = append(headers, "Region")
 	}
-	columns = append(columns, table.Column{Title: "Tags", Width: 50})
+	headers = append(headers, "Tags")
 
-	rows := make([]table.Row, len(v.filtered))
-	for i, res := range v.filtered {
+	tableHeight := v.height - 1
+	if tableHeight < 1 {
+		tableHeight = 1
+	}
+	v.tc.SetTableHeight(tableHeight)
+
+	tableWidth := v.width
+	if tableWidth < 80 {
+		tableWidth = 120
+	}
+
+	th := ui.Current()
+	cursor := v.tc.Cursor()
+
+	numCols := len(headers)
+	widths := make([]int, numCols)
+	baseWidth := tableWidth / numCols
+	remainder := tableWidth % numCols
+	for i := range widths {
+		widths[i] = baseWidth
+		if i < remainder {
+			widths[i]++
+		}
+	}
+
+	t := table.New().
+		Headers(headers...).
+		Width(tableWidth).
+		Height(tableHeight).
+		Wrap(false).
+		BorderTop(false).
+		BorderBottom(false).
+		BorderLeft(false).
+		BorderRight(false).
+		BorderColumn(false).
+		BorderHeader(true).
+		BorderStyle(lipgloss.NewStyle().Foreground(th.TableBorder)).
+		StyleFunc(func(row, col int) lipgloss.Style {
+			w := 0
+			if col < len(widths) {
+				w = widths[col]
+			}
+			s := lipgloss.NewStyle().Width(w)
+			if col == 0 {
+				s = s.PaddingLeft(1)
+			}
+			if row == table.HeaderRow {
+				return s.Bold(true).
+					Foreground(th.TableHeaderText).
+					Background(th.TableHeader)
+			}
+			if row == cursor {
+				return s.Foreground(th.SelectionText).
+					Background(th.Selection)
+			}
+			return s.Foreground(th.Text)
+		})
+
+	for _, res := range v.filtered {
 		service := ""
 		resType := ""
 		resID := ""
@@ -532,45 +630,19 @@ func (v *TagSearchView) buildTable() {
 
 		tagStr := formatTags(res.Tags, 50)
 
-		row := table.Row{service, resType, resID}
+		row := []string{service, resType, resID}
 		if isMultiRegion {
 			row = append(row, res.Region)
 		}
 		row = append(row, tagStr)
-		rows[i] = row
+		t = t.Row(row...)
 	}
 
-	tableHeight := v.height - 4
-	if tableHeight < 10 {
-		tableHeight = 20
-	}
-	tableWidth := v.width
-	if tableWidth < 80 {
-		tableWidth = 120
+	if v.tc.ScrollOffset() > 0 {
+		t = t.YOffset(v.tc.ScrollOffset())
 	}
 
-	tbl := table.New(
-		table.WithColumns(columns),
-		table.WithRows(rows),
-		table.WithFocused(true),
-		table.WithHeight(tableHeight),
-		table.WithWidth(tableWidth),
-	)
-
-	s := table.DefaultStyles()
-	theme := ui.Current()
-	s.Header = s.Header.
-		BorderStyle(lipgloss.NormalBorder()).
-		BorderForeground(theme.TableBorder).
-		BorderBottom(true).
-		Bold(false)
-	s.Selected = s.Selected.
-		Foreground(theme.SelectionText).
-		Background(theme.Selection).
-		Bold(false)
-
-	tbl.SetStyles(s)
-	v.table = tbl
+	v.tableContent = t.String()
 }
 
 func (v *TagSearchView) ViewString() string {
@@ -627,7 +699,7 @@ func (v *TagSearchView) ViewString() string {
 		return header + "\n" + status + "\n" + ui.DimStyle().Render(msg)
 	}
 
-	return header + "\n" + status + "\n" + filterView + v.table.View()
+	return header + "\n" + status + "\n" + filterView + v.tableContent
 }
 
 func (v *TagSearchView) View() tea.View {
@@ -674,9 +746,10 @@ func (v *TagSearchView) getRowAtPosition(y int) int {
 		headerHeight++
 	}
 
-	row := y - headerHeight
-	if row >= 0 && row < len(v.filtered) {
-		return row
+	visualRow := y - headerHeight
+	dataIdx := visualRow + v.tc.ScrollOffset()
+	if visualRow >= 0 && dataIdx >= 0 && dataIdx < len(v.filtered) {
+		return dataIdx
 	}
 	return -1
 }

--- a/internal/view/view_test.go
+++ b/internal/view/view_test.go
@@ -29,12 +29,14 @@ type mockRenderer struct {
 	detail string
 }
 
-func (m *mockRenderer) ServiceName() string                                     { return "test" }
-func (m *mockRenderer) ResourceType() string                                    { return "items" }
-func (m *mockRenderer) Columns() []render.Column                                { return nil }
-func (m *mockRenderer) RenderRow(r dao.Resource, cols []render.Column) []string { return nil }
-func (m *mockRenderer) RenderDetail(r dao.Resource) string                      { return m.detail }
-func (m *mockRenderer) RenderSummary(r dao.Resource) []render.SummaryField      { return nil }
+func (m *mockRenderer) ServiceName() string      { return "test" }
+func (m *mockRenderer) ResourceType() string     { return "items" }
+func (m *mockRenderer) Columns() []render.Column { return []render.Column{{Name: "NAME", Width: 20}} }
+func (m *mockRenderer) RenderRow(r dao.Resource, cols []render.Column) []string {
+	return []string{r.GetName()}
+}
+func (m *mockRenderer) RenderDetail(r dao.Resource) string                 { return m.detail }
+func (m *mockRenderer) RenderSummary(r dao.Resource) []render.SummaryField { return nil }
 
 // IsEscKey tests
 


### PR DESCRIPTION
## Summary
- Theme system with 23 configurable colors in `~/.config/claws/config.yaml`
- Migrated from bubbles/table to lipgloss/table for cell-level theming
- Extracted `TableCursor` struct to eliminate ~55 lines of duplication

Closes #96