### PR TITLE
Release v0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ Selected profiles are queried in parallel; resources display with Profile and Ac
 | `:tag <filter>` | Filter by tag |
 | `:diff <name>` | Compare current row with named resource |
 | `:diff <n1> <n2>` | Compare two named resources |
+| `:theme <name>` | Change color theme (saved if persistence enabled) |
+| `:autosave on/off` | Enable/disable config autosave (always saved) |
 
 **Login Details:**
 - `:login` runs `aws login --remote` using `claws-login` profile
@@ -413,19 +415,39 @@ concurrency:
 cloudwatch:
   window: 15m             # Metrics data window period (default: 15m)
 
-persistence:
-  enabled: true           # Save region/profile on change (default: false)
+autosave:
+  enabled: true           # Save region/profile/theme on change (default: false)
 
 startup:                  # Applied on launch if present
-  profile: production
+  profiles:               # Multiple profiles supported
+    - production
   regions:
     - us-east-1
     - us-west-2
+
+theme: nord               # Preset: dark, light, nord, dracula, gruvbox, catppuccin
+
+# Or use preset with custom overrides:
+# theme:
+#   preset: dracula
+#   primary: "#ff79c6"
+#   danger: "#ff5555"
 ```
+
+**Available Theme Presets:**
+
+| Preset | Description |
+|--------|-------------|
+| `dark` | Default dark theme (pink/magenta accents) |
+| `light` | For light-background terminals |
+| `nord` | Nordic, calm blue palette |
+| `dracula` | Popular dark theme (purple/pink) |
+| `gruvbox` | Retro, warm earth tones |
+| `catppuccin` | Modern pastel (Mocha variant) |
 
 The config file is **not created automatically**. Create it manually if needed.
 
-CLI flags (`-p`, `-r`, `--persist`, `--no-persist`) override config file settings.
+CLI flags (`-p`, `-r`, `-t`, `--autosave`, `--no-autosave`) override config file settings.
 
 For required IAM permissions, see [docs/iam-permissions.md](docs/iam-permissions.md).
 

--- a/custom/cloudformation/events/render.go
+++ b/custom/cloudformation/events/render.go
@@ -149,6 +149,6 @@ func cfnResourceStatusColorer(status string) render.Style {
 	case strings.Contains(status, "DELETE_COMPLETE") || strings.Contains(status, "SKIPPED"):
 		return ui.DimStyle()
 	default:
-		return render.DefaultStyle()
+		return ui.NoStyle()
 	}
 }

--- a/custom/cloudformation/resources/render.go
+++ b/custom/cloudformation/resources/render.go
@@ -157,7 +157,7 @@ func cfnResourceStatusColorer(status string) render.Style {
 	case strings.Contains(status, "DELETE_COMPLETE") || strings.Contains(status, "SKIPPED"):
 		return ui.DimStyle()
 	default:
-		return render.DefaultStyle()
+		return ui.NoStyle()
 	}
 }
 
@@ -171,7 +171,7 @@ func driftColorer(status string) render.Style {
 	case "NOT_CHECKED":
 		return ui.DimStyle()
 	default:
-		return render.DefaultStyle()
+		return ui.NoStyle()
 	}
 }
 

--- a/custom/cloudformation/stacks/render.go
+++ b/custom/cloudformation/stacks/render.go
@@ -253,7 +253,7 @@ func cfnStateColorer(status string) render.Style {
 	case strings.Contains(status, "DELETE_COMPLETE"):
 		return ui.DimStyle()
 	default:
-		return render.DefaultStyle()
+		return ui.NoStyle()
 	}
 }
 
@@ -267,7 +267,7 @@ func driftColorer(status string) render.Style {
 	case "NOT_CHECKED":
 		return ui.DimStyle()
 	default:
-		return render.DefaultStyle()
+		return ui.NoStyle()
 	}
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -348,7 +348,12 @@ Some views (Help, Region Selector, Profile Selector, Action Menu) display as mod
 Application configuration is stored in `~/.config/claws/config.yaml`:
 
 ```yaml
-profile: my-aws-profile
+startup:
+  profiles:
+    - my-aws-profile
+  regions:
+    - us-east-1
+theme: nord
 ```
 
 AWS credentials and config are read from standard locations:

--- a/internal/config/file_test.go
+++ b/internal/config/file_test.go
@@ -82,8 +82,8 @@ func TestDefaultFileConfig(t *testing.T) {
 	if cfg.Concurrency.MaxFetches != DefaultMaxConcurrentFetches {
 		t.Errorf("MaxFetches = %d, want %d", cfg.Concurrency.MaxFetches, DefaultMaxConcurrentFetches)
 	}
-	if cfg.Persistence.Enabled {
-		t.Error("Persistence.Enabled should be false by default")
+	if cfg.Autosave.Enabled {
+		t.Error("Autosave.Enabled should be false by default")
 	}
 }
 
@@ -111,68 +111,30 @@ func TestLoad_Save_Roundtrip(t *testing.T) {
 	defer os.Setenv("HOME", origHome)
 	os.Setenv("HOME", tmpDir)
 
-	// Create config with custom values
-	cfg := &FileConfig{
-		Timeouts: TimeoutConfig{
-			AWSInit:          Duration(10 * time.Second),
-			MultiRegionFetch: Duration(60 * time.Second),
-			TagSearch:        Duration(45 * time.Second),
-			MetricsLoad:      Duration(20 * time.Second),
-		},
-		Concurrency: ConcurrencyConfig{
-			MaxFetches: 100,
-		},
-		Persistence: PersistenceConfig{
-			Enabled: true,
-		},
-		Startup: StartupConfig{
-			Regions: []string{"us-east-1", "us-west-2"},
-			Profile: "production",
-		},
+	cfg := &FileConfig{}
+	if err := cfg.SaveRegions([]string{"us-east-1", "us-west-2"}); err != nil {
+		t.Fatalf("SaveRegions failed: %v", err)
+	}
+	if err := cfg.SaveProfiles([]string{"production"}); err != nil {
+		t.Fatalf("SaveProfiles failed: %v", err)
 	}
 
-	// Save
-	if err := cfg.Save(); err != nil {
-		t.Fatalf("Save failed: %v", err)
-	}
-
-	// Verify file exists
 	configPath := filepath.Join(tmpDir, ".config", "claws", "config.yaml")
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
 		t.Fatal("config file was not created")
 	}
 
-	// Load and verify
 	loaded, err := Load()
 	if err != nil {
 		t.Fatalf("Load failed: %v", err)
 	}
 
-	if loaded.AWSInitTimeout() != 10*time.Second {
-		t.Errorf("AWSInitTimeout() = %v, want %v", loaded.AWSInitTimeout(), 10*time.Second)
-	}
-	if loaded.MultiRegionFetchTimeout() != 60*time.Second {
-		t.Errorf("MultiRegionFetchTimeout() = %v, want %v", loaded.MultiRegionFetchTimeout(), 60*time.Second)
-	}
-	if loaded.TagSearchTimeout() != 45*time.Second {
-		t.Errorf("TagSearchTimeout() = %v, want %v", loaded.TagSearchTimeout(), 45*time.Second)
-	}
-	if loaded.MetricsLoadTimeout() != 20*time.Second {
-		t.Errorf("MetricsLoadTimeout() = %v, want %v", loaded.MetricsLoadTimeout(), 20*time.Second)
-	}
-	if loaded.MaxConcurrentFetches() != 100 {
-		t.Errorf("MaxConcurrentFetches() = %d, want %d", loaded.MaxConcurrentFetches(), 100)
-	}
-	if !loaded.PersistenceEnabled() {
-		t.Error("PersistenceEnabled() should be true")
-	}
-
-	regions, profile := loaded.GetStartup()
+	regions, profiles := loaded.GetStartup()
 	if len(regions) != 2 || regions[0] != "us-east-1" || regions[1] != "us-west-2" {
 		t.Errorf("GetStartup() regions = %v, want [us-east-1, us-west-2]", regions)
 	}
-	if profile != "production" {
-		t.Errorf("GetStartup() profile = %q, want %q", profile, "production")
+	if len(profiles) != 1 || profiles[0] != "production" {
+		t.Errorf("GetStartup() profiles = %v, want [production]", profiles)
 	}
 }
 
@@ -211,17 +173,26 @@ func TestFileConfig_ApplyDefaults_NegativeValues(t *testing.T) {
 	}
 }
 
-func TestFileConfig_SetStartup(t *testing.T) {
+func TestFileConfig_SaveRegionsProfiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", origHome)
+	os.Setenv("HOME", tmpDir)
+
 	cfg := &FileConfig{}
+	if err := cfg.SaveRegions([]string{"eu-west-1"}); err != nil {
+		t.Fatalf("SaveRegions failed: %v", err)
+	}
+	if err := cfg.SaveProfiles([]string{"dev"}); err != nil {
+		t.Fatalf("SaveProfiles failed: %v", err)
+	}
 
-	cfg.SetStartup([]string{"eu-west-1"}, "dev")
-
-	regions, profile := cfg.GetStartup()
+	regions, profiles := cfg.GetStartup()
 	if len(regions) != 1 || regions[0] != "eu-west-1" {
 		t.Errorf("GetStartup() regions = %v, want [eu-west-1]", regions)
 	}
-	if profile != "dev" {
-		t.Errorf("GetStartup() profile = %q, want %q", profile, "dev")
+	if len(profiles) != 1 || profiles[0] != "dev" {
+		t.Errorf("GetStartup() profiles = %v, want [dev]", profiles)
 	}
 }
 
@@ -252,20 +223,17 @@ func TestLoad_PartialConfig(t *testing.T) {
 	defer os.Setenv("HOME", origHome)
 	os.Setenv("HOME", tmpDir)
 
-	// Create config dir
 	configDir := filepath.Join(tmpDir, ".config", "claws")
 	if err := os.MkdirAll(configDir, 0755); err != nil {
 		t.Fatalf("MkdirAll failed: %v", err)
 	}
 
-	// Write partial config (only timeouts.aws_init)
 	configPath := filepath.Join(configDir, "config.yaml")
 	data := []byte("timeouts:\n  aws_init: 15s\n")
 	if err := os.WriteFile(configPath, data, 0644); err != nil {
 		t.Fatalf("WriteFile failed: %v", err)
 	}
 
-	// Load should fill in defaults for missing values
 	cfg, err := Load()
 	if err != nil {
 		t.Fatalf("Load failed: %v", err)
@@ -274,11 +242,440 @@ func TestLoad_PartialConfig(t *testing.T) {
 	if cfg.AWSInitTimeout() != 15*time.Second {
 		t.Errorf("AWSInitTimeout() = %v, want %v", cfg.AWSInitTimeout(), 15*time.Second)
 	}
-	// Other values should be defaults
 	if cfg.MultiRegionFetchTimeout() != DefaultMultiRegionFetchTimeout {
 		t.Errorf("MultiRegionFetchTimeout() = %v, want %v", cfg.MultiRegionFetchTimeout(), DefaultMultiRegionFetchTimeout)
 	}
 	if cfg.MaxConcurrentFetches() != DefaultMaxConcurrentFetches {
 		t.Errorf("MaxConcurrentFetches() = %d, want %d", cfg.MaxConcurrentFetches(), DefaultMaxConcurrentFetches)
 	}
+}
+
+func TestThemeConfig_UnmarshalString(t *testing.T) {
+	var cfg ThemeConfig
+	if err := yaml.Unmarshal([]byte(`"nord"`), &cfg); err != nil {
+		t.Fatalf("Unmarshal string failed: %v", err)
+	}
+	if cfg.Preset != "nord" {
+		t.Errorf("Preset = %q, want %q", cfg.Preset, "nord")
+	}
+	if cfg.Primary != "" {
+		t.Errorf("Primary should be empty, got %q", cfg.Primary)
+	}
+}
+
+func TestThemeConfig_UnmarshalObject(t *testing.T) {
+	yamlData := `
+preset: dracula
+primary: "#ff0000"
+success: "#00ff00"
+`
+	var cfg ThemeConfig
+	if err := yaml.Unmarshal([]byte(yamlData), &cfg); err != nil {
+		t.Fatalf("Unmarshal object failed: %v", err)
+	}
+	if cfg.Preset != "dracula" {
+		t.Errorf("Preset = %q, want %q", cfg.Preset, "dracula")
+	}
+	if cfg.Primary != "#ff0000" {
+		t.Errorf("Primary = %q, want %q", cfg.Primary, "#ff0000")
+	}
+	if cfg.Success != "#00ff00" {
+		t.Errorf("Success = %q, want %q", cfg.Success, "#00ff00")
+	}
+}
+
+func TestThemeConfig_UnmarshalEmpty(t *testing.T) {
+	var cfg ThemeConfig
+	if err := yaml.Unmarshal([]byte(`{}`), &cfg); err != nil {
+		t.Fatalf("Unmarshal empty failed: %v", err)
+	}
+	if cfg.Preset != "" {
+		t.Errorf("Preset should be empty, got %q", cfg.Preset)
+	}
+}
+
+func TestSave_PreservesExistingConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", origHome)
+	os.Setenv("HOME", tmpDir)
+
+	configDir := filepath.Join(tmpDir, ".config", "claws")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+
+	existing := `theme: nord
+timeouts:
+  aws_init: 10s
+custom_key: custom_value
+`
+	configPath := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(existing), 0644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	cfg := &FileConfig{}
+	if err := cfg.SaveRegions([]string{"us-west-2"}); err != nil {
+		t.Fatalf("SaveRegions failed: %v", err)
+	}
+	if err := cfg.SaveProfiles([]string{"dev", "prod"}); err != nil {
+		t.Fatalf("SaveProfiles failed: %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+	content := string(data)
+
+	if !contains(content, "theme: nord") {
+		t.Error("theme: nord was not preserved")
+	}
+	if !contains(content, "aws_init: 10s") {
+		t.Error("timeouts.aws_init was not preserved")
+	}
+	if !contains(content, "custom_key: custom_value") {
+		t.Error("custom_key was not preserved")
+	}
+	if !contains(content, "us-west-2") {
+		t.Error("region us-west-2 was not saved")
+	}
+	if !contains(content, "dev") || !contains(content, "prod") {
+		t.Error("profiles were not saved")
+	}
+}
+
+func TestSave_NewFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", origHome)
+	os.Setenv("HOME", tmpDir)
+
+	cfg := &FileConfig{}
+	if err := cfg.SaveRegions([]string{"eu-west-1"}); err != nil {
+		t.Fatalf("SaveRegions failed: %v", err)
+	}
+	if err := cfg.SaveProfiles([]string{"production"}); err != nil {
+		t.Fatalf("SaveProfiles failed: %v", err)
+	}
+
+	configPath := filepath.Join(tmpDir, ".config", "claws", "config.yaml")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+	content := string(data)
+
+	if !contains(content, "eu-west-1") {
+		t.Error("region was not saved")
+	}
+	if !contains(content, "production") {
+		t.Error("profile was not saved")
+	}
+	if contains(content, "theme") {
+		t.Error("theme should not be in new minimal file")
+	}
+}
+
+func TestSave_MultipleProfiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", origHome)
+	os.Setenv("HOME", tmpDir)
+
+	cfg := &FileConfig{}
+	profiles := []string{"dev", "prod", "__env_only__", "__sdk_default__"}
+	if err := cfg.SaveRegions([]string{"us-east-1", "us-west-2"}); err != nil {
+		t.Fatalf("SaveRegions failed: %v", err)
+	}
+	if err := cfg.SaveProfiles(profiles); err != nil {
+		t.Fatalf("SaveProfiles failed: %v", err)
+	}
+
+	loaded, err := Load()
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	regions, loadedProfiles := loaded.GetStartup()
+	if len(regions) != 2 {
+		t.Errorf("regions = %v, want 2 regions", regions)
+	}
+	if len(loadedProfiles) != 4 {
+		t.Errorf("profiles = %v, want 4 profiles", loadedProfiles)
+	}
+	for i, want := range profiles {
+		if loadedProfiles[i] != want {
+			t.Errorf("profile[%d] = %q, want %q", i, loadedProfiles[i], want)
+		}
+	}
+}
+
+func TestSave_BackwardCompatProfile(t *testing.T) {
+	tmpDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", origHome)
+	os.Setenv("HOME", tmpDir)
+
+	configDir := filepath.Join(tmpDir, ".config", "claws")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+
+	existing := `startup:
+  profile: legacy-profile
+  regions:
+    - us-east-1
+`
+	configPath := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(existing), 0644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	loaded, err := Load()
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	_, profiles := loaded.GetStartup()
+	if len(profiles) != 1 || profiles[0] != "legacy-profile" {
+		t.Errorf("profiles = %v, want [legacy-profile]", profiles)
+	}
+}
+
+func TestSave_PreservesComments(t *testing.T) {
+	tmpDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", origHome)
+	os.Setenv("HOME", tmpDir)
+
+	configDir := filepath.Join(tmpDir, ".config", "claws")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+
+	existing := `# This is a comment on theme
+theme: nord
+# This is a comment on timeouts
+timeouts:
+  aws_init: 10s
+`
+	configPath := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(existing), 0644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	cfg := &FileConfig{}
+	if err := cfg.SaveRegions([]string{"us-west-2"}); err != nil {
+		t.Fatalf("SaveRegions failed: %v", err)
+	}
+	if err := cfg.SaveProfiles([]string{"dev"}); err != nil {
+		t.Fatalf("SaveProfiles failed: %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+	content := string(data)
+
+	if !contains(content, "# This is a comment on theme") {
+		t.Error("comment on theme was not preserved")
+	}
+	if !contains(content, "# This is a comment on timeouts") {
+		t.Error("comment on timeouts was not preserved")
+	}
+}
+
+func TestSaveTheme(t *testing.T) {
+	tmpDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", origHome)
+	os.Setenv("HOME", tmpDir)
+
+	configDir := filepath.Join(tmpDir, ".config", "claws")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+
+	existing := `timeouts:
+  aws_init: 10s
+startup:
+  regions:
+    - us-east-1
+`
+	configPath := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(existing), 0644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	cfg := &FileConfig{}
+	if err := cfg.SaveTheme("nord"); err != nil {
+		t.Fatalf("SaveTheme failed: %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+	content := string(data)
+
+	if !contains(content, "theme: nord") {
+		t.Error("theme: nord was not saved")
+	}
+	if !contains(content, "aws_init: 10s") {
+		t.Error("timeouts.aws_init was not preserved")
+	}
+	if !contains(content, "us-east-1") {
+		t.Error("startup.regions was not preserved")
+	}
+
+	if cfg.GetTheme().Preset != "nord" {
+		t.Errorf("GetTheme().Preset = %q, want %q", cfg.GetTheme().Preset, "nord")
+	}
+}
+
+func TestSavePersistence(t *testing.T) {
+	tmpDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", origHome)
+	os.Setenv("HOME", tmpDir)
+
+	configDir := filepath.Join(tmpDir, ".config", "claws")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+
+	existing := `theme: nord
+startup:
+  regions:
+    - us-east-1
+`
+	configPath := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(existing), 0644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	cfg := &FileConfig{}
+	if err := cfg.SavePersistence(true); err != nil {
+		t.Fatalf("SavePersistence(true) failed: %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+	content := string(data)
+
+	if !contains(content, "autosave:") {
+		t.Error("autosave: key was not created")
+	}
+	if !contains(content, "enabled: true") {
+		t.Error("autosave.enabled: true was not saved")
+	}
+	if !contains(content, "theme: nord") {
+		t.Error("theme was not preserved")
+	}
+
+	if !cfg.PersistenceEnabled() {
+		t.Error("PersistenceEnabled() should be true")
+	}
+
+	if err := cfg.SavePersistence(false); err != nil {
+		t.Fatalf("SavePersistence(false) failed: %v", err)
+	}
+
+	data, err = os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+	content = string(data)
+
+	if !contains(content, "enabled: false") {
+		t.Error("autosave.enabled: false was not saved")
+	}
+	if cfg.PersistenceEnabled() {
+		t.Error("PersistenceEnabled() should be false")
+	}
+}
+
+func TestStartupConfig_GetProfiles(t *testing.T) {
+	tests := []struct {
+		name   string
+		config StartupConfig
+		want   []string
+	}{
+		{"new format", StartupConfig{Profiles: []string{"a", "b"}}, []string{"a", "b"}},
+		{"old format", StartupConfig{Profile: "legacy"}, []string{"legacy"}},
+		{"both prefers new", StartupConfig{Profile: "old", Profiles: []string{"new"}}, []string{"new"}},
+		{"empty", StartupConfig{}, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.config.GetProfiles()
+			if len(got) != len(tt.want) {
+				t.Errorf("GetProfiles() = %v, want %v", got, tt.want)
+				return
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("GetProfiles()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestConcurrentSaves(t *testing.T) {
+	tmpDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", origHome)
+	os.Setenv("HOME", tmpDir)
+
+	cfg := &FileConfig{}
+
+	done := make(chan bool)
+	for i := 0; i < 5; i++ {
+		go func(id int) {
+			for j := 0; j < 20; j++ {
+				_ = cfg.SaveRegions([]string{"us-east-1", "us-west-2"})
+				_ = cfg.SaveProfiles([]string{"profile1", "profile2"})
+				_ = cfg.SaveTheme("nord")
+				_ = cfg.SavePersistence(true)
+			}
+			done <- true
+		}(i)
+	}
+
+	for i := 0; i < 5; i++ {
+		<-done
+	}
+
+	loaded, err := Load()
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	regions, profiles := loaded.GetStartup()
+	if len(regions) != 2 {
+		t.Errorf("regions = %v, want 2 regions", regions)
+	}
+	if len(profiles) != 2 {
+		t.Errorf("profiles = %v, want 2 profiles", profiles)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
+}
+
+func containsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -140,7 +140,7 @@ func StateColorer() Colorer {
 		case "pending", "starting", "creating":
 			return ui.PendingStyle()
 		default:
-			return lipgloss.NewStyle()
+			return ui.NoStyle()
 		}
 	}
 }
@@ -201,11 +201,6 @@ func FormatDuration(d time.Duration) string {
 
 // Style is an alias for lipgloss.Style for convenience
 type Style = lipgloss.Style
-
-// DefaultStyle returns a default unstyled style
-func DefaultStyle() lipgloss.Style {
-	return lipgloss.NewStyle()
-}
 
 // FormatTags formats tags for table display
 // It shows the most important tags first (Name is excluded since it's usually shown separately)

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -283,7 +283,7 @@ func TestStyleHelpers(t *testing.T) {
 	_ = ui.WarningStyle().Render("test")
 	_ = ui.DangerStyle().Render("test")
 	_ = ui.DimStyle().Render("test")
-	_ = DefaultStyle().Render("test")
+	_ = ui.NoStyle().Render("test")
 }
 
 func TestEmptyValueConstants(t *testing.T) {

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -1,11 +1,57 @@
 package ui
 
 import (
+	"fmt"
 	"image/color"
+	"log/slog"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
 
 	"charm.land/bubbles/v2/spinner"
 	"charm.land/lipgloss/v2"
+
+	"github.com/clawscli/claws/internal/config"
 )
+
+var (
+	hex6Re = regexp.MustCompile(`^#[0-9A-Fa-f]{6}$`)
+	hex3Re = regexp.MustCompile(`^#[0-9A-Fa-f]{3}$`)
+)
+
+// ParseColor parses a color string and returns a lipgloss color.
+// Accepts hex (#RGB, #RRGGBB) or ANSI 256 numbers (0-255).
+// Returns nil, nil for empty strings (caller should use default).
+// Returns nil, error for invalid color strings.
+func ParseColor(s string) (color.Color, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, nil
+	}
+
+	if strings.HasPrefix(s, "#") {
+		if hex6Re.MatchString(s) {
+			return lipgloss.Color(s), nil
+		}
+		if hex3Re.MatchString(s) {
+			// Expand #RGB to #RRGGBB
+			r, g, b := s[1], s[2], s[3]
+			expanded := fmt.Sprintf("#%c%c%c%c%c%c", r, r, g, g, b, b)
+			return lipgloss.Color(expanded), nil
+		}
+		return nil, fmt.Errorf("invalid hex color %q: must be #RGB or #RRGGBB", s)
+	}
+
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return nil, fmt.Errorf("invalid color %q: must be hex (#RGB/#RRGGBB) or ANSI number (0-255)", s)
+	}
+	if n < 0 || n > 255 {
+		return nil, fmt.Errorf("invalid ANSI color %d: must be 0-255", n)
+	}
+	return lipgloss.Color(s), nil
+}
 
 // Theme defines the color scheme for the application
 type Theme struct {
@@ -39,189 +85,372 @@ type Theme struct {
 	TableHeader     color.Color // Table header background
 	TableHeaderText color.Color // Table header text
 	TableBorder     color.Color // Table border
+
+	// Badge colors (for READ-ONLY indicator, etc.)
+	BadgeForeground color.Color // Badge text color
+	BadgeBackground color.Color // Badge background color
+}
+
+// Preset theme names
+const (
+	ThemeDark       = "dark"
+	ThemeLight      = "light"
+	ThemeNord       = "nord"
+	ThemeDracula    = "dracula"
+	ThemeGruvbox    = "gruvbox"
+	ThemeCatppuccin = "catppuccin"
+)
+
+// AvailableThemes returns a list of all available preset theme names
+func AvailableThemes() []string {
+	return []string{ThemeDark, ThemeLight, ThemeNord, ThemeDracula, ThemeGruvbox, ThemeCatppuccin}
+}
+
+type palette struct {
+	primary, secondary, accent                string
+	text, textBright, textDim, textMuted      string
+	success, warning, danger, info, pending   string
+	border, borderHighlight, bg, bgAlt        string
+	selection, selectionText                  string
+	tableHeader, tableHeaderText, tableBorder string
+	badgeFg, badgeBg                          string
+}
+
+var presets = map[string]palette{
+	ThemeDark: {
+		primary: "170", secondary: "33", accent: "86",
+		text: "252", textBright: "255", textDim: "247", textMuted: "244",
+		success: "42", warning: "214", danger: "196", info: "33", pending: "226",
+		border: "244", borderHighlight: "170", bg: "235", bgAlt: "237",
+		selection: "57", selectionText: "229",
+		tableHeader: "63", tableHeaderText: "229", tableBorder: "246",
+		badgeFg: "16", badgeBg: "214",
+	},
+	ThemeLight: {
+		primary: "#8839ef", secondary: "#1e66f5", accent: "#179299",
+		text: "#4c4f69", textBright: "#1e1e2e", textDim: "#6c6f85", textMuted: "#9ca0b0",
+		success: "#40a02b", warning: "#df8e1d", danger: "#d20f39", info: "#1e66f5", pending: "#df8e1d",
+		border: "#9ca0b0", borderHighlight: "#8839ef", bg: "#eff1f5", bgAlt: "#e6e9ef",
+		selection: "#8839ef", selectionText: "#eff1f5",
+		tableHeader: "#7287fd", tableHeaderText: "#eff1f5", tableBorder: "#bcc0cc",
+		badgeFg: "#eff1f5", badgeBg: "#df8e1d",
+	},
+	ThemeNord: {
+		primary: "#88c0d0", secondary: "#81a1c1", accent: "#8fbcbb",
+		text: "#d8dee9", textBright: "#eceff4", textDim: "#4c566a", textMuted: "#434c5e",
+		success: "#a3be8c", warning: "#ebcb8b", danger: "#bf616a", info: "#5e81ac", pending: "#ebcb8b",
+		border: "#4c566a", borderHighlight: "#88c0d0", bg: "#2e3440", bgAlt: "#3b4252",
+		selection: "#5e81ac", selectionText: "#eceff4",
+		tableHeader: "#434c5e", tableHeaderText: "#88c0d0", tableBorder: "#4c566a",
+		badgeFg: "#2e3440", badgeBg: "#ebcb8b",
+	},
+	ThemeDracula: {
+		primary: "#bd93f9", secondary: "#8be9fd", accent: "#ff79c6",
+		text: "#f8f8f2", textBright: "#ffffff", textDim: "#6272a4", textMuted: "#44475a",
+		success: "#50fa7b", warning: "#ffb86c", danger: "#ff5555", info: "#8be9fd", pending: "#f1fa8c",
+		border: "#6272a4", borderHighlight: "#bd93f9", bg: "#282a36", bgAlt: "#44475a",
+		selection: "#44475a", selectionText: "#f8f8f2",
+		tableHeader: "#44475a", tableHeaderText: "#bd93f9", tableBorder: "#6272a4",
+		badgeFg: "#282a36", badgeBg: "#ffb86c",
+	},
+	ThemeGruvbox: {
+		primary: "#fe8019", secondary: "#83a598", accent: "#fabd2f",
+		text: "#ebdbb2", textBright: "#fbf1c7", textDim: "#928374", textMuted: "#665c54",
+		success: "#b8bb26", warning: "#fabd2f", danger: "#fb4934", info: "#83a598", pending: "#fabd2f",
+		border: "#665c54", borderHighlight: "#fe8019", bg: "#282828", bgAlt: "#3c3836",
+		selection: "#504945", selectionText: "#fbf1c7",
+		tableHeader: "#3c3836", tableHeaderText: "#fe8019", tableBorder: "#665c54",
+		badgeFg: "#282828", badgeBg: "#fabd2f",
+	},
+	ThemeCatppuccin: {
+		primary: "#cba6f7", secondary: "#89b4fa", accent: "#f5c2e7",
+		text: "#cdd6f4", textBright: "#ffffff", textDim: "#6c7086", textMuted: "#585b70",
+		success: "#a6e3a1", warning: "#f9e2af", danger: "#f38ba8", info: "#89dceb", pending: "#f9e2af",
+		border: "#585b70", borderHighlight: "#cba6f7", bg: "#1e1e2e", bgAlt: "#313244",
+		selection: "#45475a", selectionText: "#cdd6f4",
+		tableHeader: "#313244", tableHeaderText: "#cba6f7", tableBorder: "#585b70",
+		badgeFg: "#1e1e2e", badgeBg: "#f9e2af",
+	},
+}
+
+func buildTheme(p palette) *Theme {
+	return &Theme{
+		Primary:         lipgloss.Color(p.primary),
+		Secondary:       lipgloss.Color(p.secondary),
+		Accent:          lipgloss.Color(p.accent),
+		Text:            lipgloss.Color(p.text),
+		TextBright:      lipgloss.Color(p.textBright),
+		TextDim:         lipgloss.Color(p.textDim),
+		TextMuted:       lipgloss.Color(p.textMuted),
+		Success:         lipgloss.Color(p.success),
+		Warning:         lipgloss.Color(p.warning),
+		Danger:          lipgloss.Color(p.danger),
+		Info:            lipgloss.Color(p.info),
+		Pending:         lipgloss.Color(p.pending),
+		Border:          lipgloss.Color(p.border),
+		BorderHighlight: lipgloss.Color(p.borderHighlight),
+		Background:      lipgloss.Color(p.bg),
+		BackgroundAlt:   lipgloss.Color(p.bgAlt),
+		Selection:       lipgloss.Color(p.selection),
+		SelectionText:   lipgloss.Color(p.selectionText),
+		TableHeader:     lipgloss.Color(p.tableHeader),
+		TableHeaderText: lipgloss.Color(p.tableHeaderText),
+		TableBorder:     lipgloss.Color(p.tableBorder),
+		BadgeForeground: lipgloss.Color(p.badgeFg),
+		BadgeBackground: lipgloss.Color(p.badgeBg),
+	}
+}
+
+// GetPreset returns a theme by name. Returns nil if the name is not recognized.
+func GetPreset(name string) *Theme {
+	key := strings.ToLower(strings.TrimSpace(name))
+	if key == "" {
+		key = ThemeDark
+	}
+	if p, ok := presets[key]; ok {
+		return buildTheme(p)
+	}
+	return nil
 }
 
 // DefaultTheme returns the default dark theme
 func DefaultTheme() *Theme {
-	return &Theme{
-		// Primary colors
-		Primary:   lipgloss.Color("170"), // Pink/Magenta
-		Secondary: lipgloss.Color("33"),  // Blue
-		Accent:    lipgloss.Color("86"),  // Cyan
-
-		// Text colors
-		Text:       lipgloss.Color("252"), // Light gray
-		TextBright: lipgloss.Color("255"), // White
-		TextDim:    lipgloss.Color("247"), // Medium gray
-		TextMuted:  lipgloss.Color("244"), // Darker gray
-
-		// Semantic colors
-		Success: lipgloss.Color("42"),  // Green
-		Warning: lipgloss.Color("214"), // Orange
-		Danger:  lipgloss.Color("196"), // Red
-		Info:    lipgloss.Color("33"),  // Blue
-		Pending: lipgloss.Color("226"), // Yellow
-
-		// UI element colors
-		Border:          lipgloss.Color("244"), // Gray border
-		BorderHighlight: lipgloss.Color("170"), // Pink highlight
-		Background:      lipgloss.Color("235"), // Dark background
-		BackgroundAlt:   lipgloss.Color("237"), // Slightly lighter
-		Selection:       lipgloss.Color("57"),  // Purple selection
-		SelectionText:   lipgloss.Color("229"), // Light yellow
-
-		// Table colors
-		TableHeader:     lipgloss.Color("63"),  // Purple header
-		TableHeaderText: lipgloss.Color("229"), // Light yellow
-		TableBorder:     lipgloss.Color("246"), // Gray border
-	}
+	return buildTheme(presets[ThemeDark])
 }
 
 // current holds the active theme
-var current = DefaultTheme()
+var (
+	currentMu sync.RWMutex
+	current   = DefaultTheme()
+)
 
 // Current returns the current active theme
 func Current() *Theme {
+	currentMu.RLock()
+	defer currentMu.RUnlock()
 	return current
+}
+
+func SetTheme(t *Theme) {
+	if t != nil {
+		currentMu.Lock()
+		current = t
+		currentMu.Unlock()
+	}
+}
+
+func ApplyConfig(cfg config.ThemeConfig) {
+	ApplyConfigWithOverride(cfg, "")
+}
+
+func ApplyConfigWithOverride(cfg config.ThemeConfig, cliTheme string) {
+	presetName := cfg.Preset
+	if cliTheme != "" {
+		presetName = cliTheme
+	}
+
+	theme := GetPreset(presetName)
+	if theme == nil {
+		slog.Warn("unknown theme preset, using dark", "preset", presetName)
+		theme = DefaultTheme()
+	}
+
+	if cliTheme != "" {
+		SetTheme(theme)
+		return
+	}
+
+	applyColor := func(name string, value string, target *color.Color) {
+		if value == "" {
+			return
+		}
+		c, err := ParseColor(value)
+		if err != nil {
+			slog.Warn("invalid theme color, using default", "field", name, "value", value, "error", err)
+			return
+		}
+		*target = c
+	}
+
+	applyColor("primary", cfg.Primary, &theme.Primary)
+	applyColor("secondary", cfg.Secondary, &theme.Secondary)
+	applyColor("accent", cfg.Accent, &theme.Accent)
+	applyColor("text", cfg.Text, &theme.Text)
+	applyColor("text_bright", cfg.TextBright, &theme.TextBright)
+	applyColor("text_dim", cfg.TextDim, &theme.TextDim)
+	applyColor("text_muted", cfg.TextMuted, &theme.TextMuted)
+	applyColor("success", cfg.Success, &theme.Success)
+	applyColor("warning", cfg.Warning, &theme.Warning)
+	applyColor("danger", cfg.Danger, &theme.Danger)
+	applyColor("info", cfg.Info, &theme.Info)
+	applyColor("pending", cfg.Pending, &theme.Pending)
+	applyColor("border", cfg.Border, &theme.Border)
+	applyColor("border_highlight", cfg.BorderHighlight, &theme.BorderHighlight)
+	applyColor("background", cfg.Background, &theme.Background)
+	applyColor("background_alt", cfg.BackgroundAlt, &theme.BackgroundAlt)
+	applyColor("selection", cfg.Selection, &theme.Selection)
+	applyColor("selection_text", cfg.SelectionText, &theme.SelectionText)
+	applyColor("table_header", cfg.TableHeader, &theme.TableHeader)
+	applyColor("table_header_text", cfg.TableHeaderText, &theme.TableHeaderText)
+	applyColor("table_border", cfg.TableBorder, &theme.TableBorder)
+	applyColor("badge_foreground", cfg.BadgeForeground, &theme.BadgeForeground)
+	applyColor("badge_background", cfg.BadgeBackground, &theme.BadgeBackground)
+
+	SetTheme(theme)
 }
 
 // Style helpers that use the current theme
 
-// DimStyle returns a style for dimmed text
+func NoStyle() lipgloss.Style {
+	return lipgloss.NewStyle()
+}
+
 func DimStyle() lipgloss.Style {
-	return lipgloss.NewStyle().Foreground(current.TextDim)
+	return lipgloss.NewStyle().Foreground(Current().TextDim)
 }
 
 // SuccessStyle returns a style for success states
 func SuccessStyle() lipgloss.Style {
-	return lipgloss.NewStyle().Foreground(current.Success)
+	return lipgloss.NewStyle().Foreground(Current().Success)
 }
 
 // WarningStyle returns a style for warning states
 func WarningStyle() lipgloss.Style {
-	return lipgloss.NewStyle().Foreground(current.Warning)
+	return lipgloss.NewStyle().Foreground(Current().Warning)
 }
 
 // DangerStyle returns a style for danger/error states
 func DangerStyle() lipgloss.Style {
-	return lipgloss.NewStyle().Foreground(current.Danger)
+	return lipgloss.NewStyle().Foreground(Current().Danger)
 }
 
 func TitleStyle() lipgloss.Style {
-	return lipgloss.NewStyle().Bold(true).Foreground(current.Primary)
+	return lipgloss.NewStyle().Bold(true).Foreground(Current().Primary)
 }
 
 func SelectedStyle() lipgloss.Style {
-	return lipgloss.NewStyle().Background(current.Selection).Foreground(current.SelectionText)
+	return lipgloss.NewStyle().Background(Current().Selection).Foreground(Current().SelectionText)
 }
 
 func TableHeaderStyle() lipgloss.Style {
-	return lipgloss.NewStyle().Background(current.TableHeader).Foreground(current.TableHeaderText)
+	return lipgloss.NewStyle().Background(Current().TableHeader).Foreground(Current().TableHeaderText)
 }
 
 func SectionStyle() lipgloss.Style {
-	return lipgloss.NewStyle().Bold(true).Foreground(current.Secondary)
+	return lipgloss.NewStyle().Bold(true).Foreground(Current().Secondary)
 }
 
 func HighlightStyle() lipgloss.Style {
-	return lipgloss.NewStyle().Bold(true).Foreground(current.Accent)
+	return lipgloss.NewStyle().Bold(true).Foreground(Current().Accent)
 }
 
 func BoldSuccessStyle() lipgloss.Style {
-	return lipgloss.NewStyle().Bold(true).Foreground(current.Success)
+	return lipgloss.NewStyle().Bold(true).Foreground(Current().Success)
 }
 
 func BoldDangerStyle() lipgloss.Style {
-	return lipgloss.NewStyle().Bold(true).Foreground(current.Danger)
+	return lipgloss.NewStyle().Bold(true).Foreground(Current().Danger)
 }
 
 func BoldWarningStyle() lipgloss.Style {
-	return lipgloss.NewStyle().Bold(true).Foreground(current.Warning)
+	return lipgloss.NewStyle().Bold(true).Foreground(Current().Warning)
 }
 
 func BoldPendingStyle() lipgloss.Style {
-	return lipgloss.NewStyle().Bold(true).Foreground(current.Pending)
+	return lipgloss.NewStyle().Bold(true).Foreground(Current().Pending)
 }
 
 // AccentStyle returns a style for accent-colored text (non-bold)
 func AccentStyle() lipgloss.Style {
-	return lipgloss.NewStyle().Foreground(current.Accent)
+	return lipgloss.NewStyle().Foreground(Current().Accent)
 }
 
 // MutedStyle returns a style for very dim/muted text
 func MutedStyle() lipgloss.Style {
-	return lipgloss.NewStyle().Foreground(current.TextMuted)
+	return lipgloss.NewStyle().Foreground(Current().TextMuted)
 }
 
 // TextStyle returns a style for normal text
 func TextStyle() lipgloss.Style {
-	return lipgloss.NewStyle().Foreground(current.Text)
+	return lipgloss.NewStyle().Foreground(Current().Text)
 }
 
 // TextBrightStyle returns a style for emphasized text
 func TextBrightStyle() lipgloss.Style {
-	return lipgloss.NewStyle().Foreground(current.TextBright)
+	return lipgloss.NewStyle().Foreground(Current().TextBright)
 }
 
 // SecondaryStyle returns a style for secondary-colored text
 func SecondaryStyle() lipgloss.Style {
-	return lipgloss.NewStyle().Foreground(current.Secondary)
+	return lipgloss.NewStyle().Foreground(Current().Secondary)
 }
 
 // BorderStyle returns a style for border-colored text (separators)
 func BorderStyle() lipgloss.Style {
-	return lipgloss.NewStyle().Foreground(current.Border)
+	return lipgloss.NewStyle().Foreground(Current().Border)
 }
 
 // PrimaryStyle returns a style for primary-colored text (non-bold)
 func PrimaryStyle() lipgloss.Style {
-	return lipgloss.NewStyle().Foreground(current.Primary)
+	return lipgloss.NewStyle().Foreground(Current().Primary)
 }
 
 // InfoStyle returns a style for info states
 func InfoStyle() lipgloss.Style {
-	return lipgloss.NewStyle().Foreground(current.Info)
+	return lipgloss.NewStyle().Foreground(Current().Info)
 }
 
 // PendingStyle returns a style for pending states
 func PendingStyle() lipgloss.Style {
-	return lipgloss.NewStyle().Foreground(current.Pending)
+	return lipgloss.NewStyle().Foreground(Current().Pending)
+}
+
+func FaintStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Faint(true)
 }
 
 func BoxStyle() lipgloss.Style {
 	return lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(current.Border).
+		BorderForeground(Current().Border).
 		Padding(0, 1)
 }
 
 func InputStyle() lipgloss.Style {
 	return lipgloss.NewStyle().
 		Border(lipgloss.NormalBorder()).
-		BorderForeground(current.Border).
+		BorderForeground(Current().Border).
 		Padding(0, 1)
 }
 
 // InputFieldStyle returns a style for input fields (filter, command input)
 func InputFieldStyle() lipgloss.Style {
 	return lipgloss.NewStyle().
-		Background(current.Background).
-		Foreground(current.Text).
+		Background(Current().Background).
+		Foreground(Current().Text).
 		Padding(0, 1)
 }
 
 // ReadOnlyBadgeStyle returns a style for the READ-ONLY indicator badge
 func ReadOnlyBadgeStyle() lipgloss.Style {
 	return lipgloss.NewStyle().
-		Background(current.Warning).
-		Foreground(lipgloss.Color("#000000")). // TODO: extract to theme in #96
+		Background(Current().BadgeBackground).
+		Foreground(Current().BadgeForeground).
 		Bold(true).
+		Padding(0, 1)
+}
+
+func CellStyle(width, height int) lipgloss.Style {
+	return lipgloss.NewStyle().
+		Foreground(Current().Text).
+		Width(width).
+		Height(height).
 		Padding(0, 1)
 }
 
 func NewSpinner() spinner.Model {
 	s := spinner.New()
 	s.Spinner = spinner.Dot
-	s.Style = lipgloss.NewStyle().Foreground(current.Accent)
+	s.Style = lipgloss.NewStyle().Foreground(Current().Accent)
 	return s
 }

--- a/internal/view/action_menu.go
+++ b/internal/view/action_menu.go
@@ -37,14 +37,14 @@ func newActionMenuStyles() actionMenuStyles {
 	t := ui.Current()
 	return actionMenuStyles{
 		title:     ui.TitleStyle(),
-		item:      lipgloss.NewStyle().PaddingLeft(2),
+		item:      ui.TextStyle(),
 		selected:  ui.SelectedStyle().PaddingLeft(2),
 		shortcut:  ui.SecondaryStyle(),
 		box:       ui.BoxStyle().MarginTop(1),
 		dangerBox: ui.BoxStyle().BorderForeground(t.Danger).MarginTop(1),
 		yes:       ui.BoldSuccessStyle(),
 		no:        ui.BoldDangerStyle(),
-		bold:      lipgloss.NewStyle().Bold(true),
+		bold:      ui.TextStyle().Bold(true),
 		input:     ui.InputStyle(),
 	}
 }
@@ -124,6 +124,9 @@ func (m *ActionMenu) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, func() tea.Msg { return followUp }
 			}
 		}
+		return m, nil
+	case ThemeChangedMsg:
+		m.styles = newActionMenuStyles()
 		return m, nil
 
 	case tea.MouseMotionMsg:
@@ -299,13 +302,12 @@ func (m *ActionMenu) ViewString() string {
 	}
 
 	for i, act := range m.actions {
-		style := s.item
+		shortcutText := fmt.Sprintf("[%s]", act.Shortcut)
 		if i == m.cursor {
-			style = s.selected
+			out += s.selected.Render(fmt.Sprintf("%s %s", shortcutText, act.Name)) + "\n"
+		} else {
+			out += fmt.Sprintf("  %s %s", s.shortcut.Render(shortcutText), s.item.Render(act.Name)) + "\n"
 		}
-
-		shortcut := s.shortcut.Render(fmt.Sprintf("[%s]", act.Shortcut))
-		out += style.Render(fmt.Sprintf("%s %s", shortcut, act.Name)) + "\n"
 	}
 
 	if m.dangerous.active && m.confirmIdx < len(m.actions) {

--- a/internal/view/command_input.go
+++ b/internal/view/command_input.go
@@ -90,6 +90,10 @@ func (c *CommandInput) Activate() tea.Cmd {
 	return textinput.Blink
 }
 
+func (c *CommandInput) ReloadStyles() {
+	c.styles = newCommandInputStyles()
+}
+
 // Deactivate deactivates command mode
 func (c *CommandInput) Deactivate() {
 	c.active = false
@@ -279,14 +283,34 @@ func (c *CommandInput) executeCommand() (tea.Cmd, *NavigateMsg) {
 	if suffix, ok := strings.CutPrefix(input, "diff "); ok {
 		parts := strings.Fields(suffix)
 		if len(parts) == 1 {
-			// :diff <name> - compare current row with named resource
 			return func() tea.Msg {
 				return DiffMsg{LeftName: "", RightName: parts[0]}
 			}, nil
 		} else if len(parts) >= 2 {
-			// :diff <name1> <name2> - compare two named resources
 			return func() tea.Msg {
 				return DiffMsg{LeftName: parts[0], RightName: parts[1]}
+			}, nil
+		}
+	}
+
+	if suffix, ok := strings.CutPrefix(input, "theme "); ok {
+		themeName := strings.TrimSpace(suffix)
+		if themeName != "" {
+			return func() tea.Msg {
+				return ThemeChangeMsg{Name: themeName}
+			}, nil
+		}
+	}
+
+	if suffix, ok := strings.CutPrefix(input, "autosave "); ok {
+		switch strings.TrimSpace(suffix) {
+		case "on":
+			return func() tea.Msg {
+				return PersistenceChangeMsg{Enabled: true}
+			}, nil
+		case "off":
+			return func() tea.Msg {
+				return PersistenceChangeMsg{Enabled: false}
 			}, nil
 		}
 	}
@@ -391,6 +415,14 @@ func (c *CommandInput) GetSuggestions() []string {
 		return c.getDiffSuggestions(suffix)
 	}
 
+	if suffix, ok := strings.CutPrefix(input, "theme "); ok {
+		return c.getThemeSuggestions(suffix)
+	}
+
+	if suffix, ok := strings.CutPrefix(input, "autosave "); ok {
+		return c.getAutosaveSuggestions(suffix)
+	}
+
 	if strings.Contains(input, "/") {
 		// Suggest resources
 		parts := strings.SplitN(input, "/", 2)
@@ -441,6 +473,14 @@ func (c *CommandInput) GetSuggestions() []string {
 			suggestions = append(suggestions, "diff")
 		}
 
+		if strings.HasPrefix("theme", input) {
+			suggestions = append(suggestions, "theme")
+		}
+
+		if strings.HasPrefix("autosave", input) {
+			suggestions = append(suggestions, "autosave")
+		}
+
 		for _, svc := range c.registry.ListServices() {
 			if strings.HasPrefix(svc, input) {
 				suggestions = append(suggestions, svc)
@@ -456,6 +496,32 @@ func (c *CommandInput) GetSuggestions() []string {
 		slices.Sort(suggestions)
 	}
 
+	return suggestions
+}
+
+func (c *CommandInput) getThemeSuggestions(prefix string) []string {
+	themes := ui.AvailableThemes()
+	prefix = strings.ToLower(strings.TrimSpace(prefix))
+
+	var suggestions []string
+	for _, t := range themes {
+		if prefix == "" || strings.HasPrefix(t, prefix) {
+			suggestions = append(suggestions, "theme "+t)
+		}
+	}
+	return suggestions
+}
+
+func (c *CommandInput) getAutosaveSuggestions(prefix string) []string {
+	prefix = strings.ToLower(strings.TrimSpace(prefix))
+	options := []string{"on", "off"}
+
+	var suggestions []string
+	for _, opt := range options {
+		if prefix == "" || strings.HasPrefix(opt, prefix) {
+			suggestions = append(suggestions, "autosave "+opt)
+		}
+	}
 	return suggestions
 }
 

--- a/internal/view/dashboard_view.go
+++ b/internal/view/dashboard_view.go
@@ -21,6 +21,7 @@ type hitArea struct {
 }
 
 type dashboardStyles struct {
+	text      lipgloss.Style
 	warning   lipgloss.Style
 	danger    lipgloss.Style
 	success   lipgloss.Style
@@ -30,6 +31,7 @@ type dashboardStyles struct {
 
 func newDashboardStyles() dashboardStyles {
 	return dashboardStyles{
+		text:      ui.TextStyle(),
 		warning:   ui.WarningStyle(),
 		danger:    ui.DangerStyle(),
 		success:   ui.SuccessStyle(),
@@ -186,6 +188,10 @@ func (d *DashboardView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case RefreshMsg:
 		return d.handleRefresh()
+	case ThemeChangedMsg:
+		d.styles = newDashboardStyles()
+		d.headerPanel.ReloadStyles()
+		return d, nil
 
 	case tea.MouseClickMsg:
 		return d.handleMouseClick(msg)

--- a/internal/view/dashboard_view_panels.go
+++ b/internal/view/dashboard_view_panels.go
@@ -47,10 +47,8 @@ func renderPanel(title, content string, width, height int, t *ui.Theme, hovered 
 		borderColor = t.Primary
 	}
 
-	borderStyle := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
+	borderStyle := ui.BoxStyle().
 		BorderForeground(borderColor).
-		Padding(0, 1).
 		Width(width).
 		Height(boxHeight)
 
@@ -78,11 +76,11 @@ func (d *DashboardView) renderCostContent(contentWidth, contentHeight int, t *ui
 	var lines []string
 
 	if d.costLoading {
-		lines = append(lines, d.spinner.View()+" loading...")
+		lines = append(lines, s.text.Render(d.spinner.View()+" loading..."))
 	} else if d.costErr != nil {
 		lines = append(lines, s.dim.Render("Cost: N/A"))
 	} else {
-		lines = append(lines, "MTD: "+appaws.FormatMoney(d.costMTD, ""))
+		lines = append(lines, s.text.Render("MTD: "+appaws.FormatMoney(d.costMTD, "")))
 
 		if len(d.costTop) > 0 {
 			maxCost := d.costTop[0].cost
@@ -101,19 +99,21 @@ func (d *DashboardView) renderCostContent(contentWidth, contentHeight int, t *ui
 				line := fmt.Sprintf("%-*s %s %8.0f", nameWidth, name, bar, c.cost)
 				if i == focusRow {
 					line = s.highlight.Render(line)
+				} else {
+					line = s.text.Render(line)
 				}
 				lines = append(lines, line)
 			}
 		}
 
 		if d.anomalyLoading {
-			lines = append(lines, "Anomalies: "+d.spinner.View())
+			lines = append(lines, s.text.Render("Anomalies: "+d.spinner.View()))
 		} else if d.anomalyErr != nil {
-			lines = append(lines, "Anomalies: "+s.dim.Render("N/A"))
+			lines = append(lines, s.text.Render("Anomalies: ")+s.dim.Render("N/A"))
 		} else if d.anomalyCount > 0 {
-			lines = append(lines, "Anomalies: "+s.warning.Render(fmt.Sprintf("%d", d.anomalyCount)))
+			lines = append(lines, s.text.Render("Anomalies: ")+s.warning.Render(fmt.Sprintf("%d", d.anomalyCount)))
 		} else {
-			lines = append(lines, "Anomalies: "+s.success.Render("0"))
+			lines = append(lines, s.text.Render("Anomalies: ")+s.success.Render("0"))
 		}
 	}
 
@@ -126,25 +126,25 @@ func (d *DashboardView) renderOpsContent(contentWidth, contentHeight int, focusR
 	alarmCount := len(d.alarms)
 
 	if d.alarmLoading {
-		lines = append(lines, "Alarms: "+d.spinner.View())
+		lines = append(lines, s.text.Render("Alarms: "+d.spinner.View()))
 	} else if d.alarmErr != nil {
 		lines = append(lines, s.dim.Render("Alarms: N/A"))
 	} else if alarmCount > 0 {
 		lines = append(lines, s.danger.Render(fmt.Sprintf("Alarms: %d in ALARM", alarmCount)))
 		maxShow := min(alarmCount, contentHeight-3)
 		for i := range maxShow {
-			line := "  " + s.danger.Render("• ") + TruncateString(d.alarms[i].name, contentWidth-bulletIndentWidth)
+			line := "  " + s.danger.Render("• ") + s.text.Render(TruncateString(d.alarms[i].name, contentWidth-bulletIndentWidth))
 			if i == focusRow {
 				line = s.highlight.Render(line)
 			}
 			lines = append(lines, line)
 		}
 	} else {
-		lines = append(lines, "Alarms: "+s.success.Render("0 ✓"))
+		lines = append(lines, s.text.Render("Alarms: ")+s.success.Render("0 ✓"))
 	}
 
 	if d.healthLoading {
-		lines = append(lines, "Health: "+d.spinner.View())
+		lines = append(lines, s.text.Render("Health: "+d.spinner.View()))
 	} else if d.healthErr != nil {
 		lines = append(lines, s.dim.Render("Health: N/A"))
 	} else if len(d.healthItems) > 0 {
@@ -153,14 +153,14 @@ func (d *DashboardView) renderOpsContent(contentWidth, contentHeight int, focusR
 		maxShow := min(len(d.healthItems), remaining)
 		for i := range maxShow {
 			h := d.healthItems[i]
-			line := "  " + s.warning.Render("• ") + TruncateString(h.service+": "+h.eventType, contentWidth-bulletIndentWidth)
+			line := "  " + s.warning.Render("• ") + s.text.Render(TruncateString(h.service+": "+h.eventType, contentWidth-bulletIndentWidth))
 			if alarmCount+i == focusRow {
 				line = s.highlight.Render(line)
 			}
 			lines = append(lines, line)
 		}
 	} else {
-		lines = append(lines, "Health: "+s.success.Render("0 open ✓"))
+		lines = append(lines, s.text.Render("Health: ")+s.success.Render("0 open ✓"))
 	}
 
 	return strings.Join(lines, "\n")
@@ -171,7 +171,7 @@ func (d *DashboardView) renderSecurityContent(contentWidth, contentHeight int, f
 	var lines []string
 
 	if d.secLoading {
-		lines = append(lines, d.spinner.View()+" loading...")
+		lines = append(lines, s.text.Render(d.spinner.View()+" loading..."))
 	} else if d.secErr != nil {
 		lines = append(lines, s.dim.Render("Security: N/A"))
 	} else if len(d.secItems) > 0 {
@@ -196,7 +196,7 @@ func (d *DashboardView) renderSecurityContent(contentWidth, contentHeight int, f
 			if item.severity == "CRITICAL" {
 				style = s.danger
 			}
-			line := "  " + style.Render("• ") + TruncateString(item.title, contentWidth-bulletIndentWidth)
+			line := "  " + style.Render("• ") + s.text.Render(TruncateString(item.title, contentWidth-bulletIndentWidth))
 			if i == focusRow {
 				line = s.highlight.Render(line)
 			}
@@ -214,7 +214,7 @@ func (d *DashboardView) renderOptimizationContent(contentWidth, contentHeight in
 	var lines []string
 
 	if d.taLoading {
-		lines = append(lines, d.spinner.View()+" loading...")
+		lines = append(lines, s.text.Render(d.spinner.View()+" loading..."))
 	} else if d.taErr != nil {
 		lines = append(lines, s.dim.Render("Optimization: N/A"))
 	} else {
@@ -243,7 +243,7 @@ func (d *DashboardView) renderOptimizationContent(contentWidth, contentHeight in
 				if item.status == "error" {
 					style = s.danger
 				}
-				line := "  " + style.Render("• ") + TruncateString(item.name, contentWidth-bulletIndentWidth)
+				line := "  " + style.Render("• ") + s.text.Render(TruncateString(item.name, contentWidth-bulletIndentWidth))
 				if i == focusRow {
 					line = s.highlight.Render(line)
 				}

--- a/internal/view/detail_view.go
+++ b/internal/view/detail_view.go
@@ -121,6 +121,13 @@ func (d *DetailView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return d, cmd
 		}
 		return d, nil
+	case ThemeChangedMsg:
+		d.styles = newDetailViewStyles()
+		d.headerPanel.ReloadStyles()
+		if d.vp.Ready {
+			d.vp.Model.SetContent(d.renderContent())
+		}
+		return d, nil
 
 	case tea.KeyPressMsg:
 		// Let app handle back navigation (esc/backspace/q handled by app.go)

--- a/internal/view/diff_view.go
+++ b/internal/view/diff_view.go
@@ -64,6 +64,12 @@ func (d *DiffView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if IsEscKey(msg) {
 			return d, nil
 		}
+	case ThemeChangedMsg:
+		d.styles = newDiffViewStyles()
+		if d.vp.Ready {
+			d.vp.Model.SetContent(d.renderSideBySide())
+		}
+		return d, nil
 	}
 
 	var cmd tea.Cmd

--- a/internal/view/header_panel.go
+++ b/internal/view/header_panel.go
@@ -33,9 +33,8 @@ type headerPanelStyles struct {
 }
 
 func newHeaderPanelStyles() headerPanelStyles {
-	t := ui.Current()
 	return headerPanelStyles{
-		panel:     lipgloss.NewStyle().BorderStyle(lipgloss.RoundedBorder()).BorderForeground(t.Border).Padding(0, 1),
+		panel:     ui.BoxStyle(),
 		label:     ui.DimStyle(),
 		value:     ui.TextStyle(),
 		accent:    ui.HighlightStyle(),
@@ -126,6 +125,10 @@ func formatMultiAccounts(selections []config.ProfileSelection, accountIDs map[st
 // SetWidth sets the panel width
 func (h *HeaderPanel) SetWidth(width int) {
 	h.width = width
+}
+
+func (h *HeaderPanel) ReloadStyles() {
+	h.styles = newHeaderPanelStyles()
 }
 
 // Height returns the number of lines the rendered header will take

--- a/internal/view/help_view.go
+++ b/internal/view/help_view.go
@@ -43,6 +43,14 @@ func (h *HelpView) Init() tea.Cmd {
 }
 
 func (h *HelpView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg.(type) {
+	case ThemeChangedMsg:
+		h.styles = newHelpViewStyles()
+		if h.vp.Ready {
+			h.vp.Model.SetContent(h.renderContent())
+		}
+		return h, nil
+	}
 	var cmd tea.Cmd
 	h.vp.Model, cmd = h.vp.Model.Update(msg)
 	return h, cmd

--- a/internal/view/log_view.go
+++ b/internal/view/log_view.go
@@ -333,6 +333,12 @@ func (v *LogView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			v.spinner, cmd = v.spinner.Update(msg)
 			return v, cmd
 		}
+	case ThemeChangedMsg:
+		v.styles = newLogViewStyles()
+		if v.vp.Ready {
+			v.updateViewportContent()
+		}
+		return v, nil
 	}
 
 	if v.vp.Ready {

--- a/internal/view/modal.go
+++ b/internal/view/modal.go
@@ -43,12 +43,8 @@ type modalStyles struct {
 }
 
 func newModalStyles() modalStyles {
-	t := ui.Current()
 	return modalStyles{
-		box: lipgloss.NewStyle().
-			Border(lipgloss.RoundedBorder()).
-			BorderForeground(t.Border).
-			Padding(1, 2),
+		box: ui.BoxStyle().Padding(1, 2),
 	}
 }
 
@@ -60,6 +56,10 @@ func NewModalRenderer() *ModalRenderer {
 	return &ModalRenderer{
 		styles: newModalStyles(),
 	}
+}
+
+func (r *ModalRenderer) ReloadStyles() {
+	r.styles = newModalStyles()
 }
 
 func (r *ModalRenderer) Render(modal *Modal, bg string, width, height int) string {
@@ -83,11 +83,11 @@ func (r *ModalRenderer) Render(modal *Modal, bg string, width, height int) strin
 }
 
 func dimBackground(bg string, width, height int) string {
-	dimStyle := lipgloss.NewStyle().Faint(true)
+	faintStyle := ui.FaintStyle()
 	lines := strings.Split(bg, "\n")
 
 	for i, line := range lines {
-		lines[i] = dimStyle.Render(line)
+		lines[i] = faintStyle.Render(line)
 	}
 
 	for len(lines) < height {

--- a/internal/view/multi_selector.go
+++ b/internal/view/multi_selector.go
@@ -26,7 +26,7 @@ type selectorStyles struct {
 func newSelectorStyles() selectorStyles {
 	return selectorStyles{
 		title:        ui.TableHeaderStyle().Padding(0, 1),
-		item:         lipgloss.NewStyle().PaddingLeft(2),
+		item:         ui.TextStyle().PaddingLeft(2),
 		itemSelected: ui.SelectedStyle().PaddingLeft(2),
 		itemChecked:  ui.SuccessStyle().PaddingLeft(2),
 		filter:       ui.AccentStyle(),
@@ -80,6 +80,11 @@ func (m *MultiSelector[T]) SetItems(items []T) {
 			break
 		}
 	}
+	m.updateViewport()
+}
+
+func (m *MultiSelector[T]) ReloadStyles() {
+	m.styles = newSelectorStyles()
 	m.updateViewport()
 }
 

--- a/internal/view/profile_selector.go
+++ b/internal/view/profile_selector.go
@@ -113,6 +113,9 @@ func (p *ProfileSelector) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		p.profileInfo = msg.infoMap
 		p.selector.SetItems(p.profiles)
 		return p, nil
+	case ThemeChangedMsg:
+		p.selector.ReloadStyles()
+		return p, nil
 
 	case loginResultMsg:
 		p.loginResult = &msg

--- a/internal/view/region_selector.go
+++ b/internal/view/region_selector.go
@@ -91,7 +91,9 @@ func (r *RegionSelector) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		r.selector.SetItems(r.regions)
 		return r, nil
-
+	case ThemeChangedMsg:
+		r.selector.ReloadStyles()
+		return r, nil
 	}
 
 	cmd, result := r.selector.HandleUpdate(msg)

--- a/internal/view/resource_browser_fetch.go
+++ b/internal/view/resource_browser_fetch.go
@@ -385,7 +385,7 @@ func (r *ResourceBrowser) shouldLoadNextPage() bool {
 		return false
 	}
 	buffer := 10
-	return r.table.Cursor() >= len(r.filtered)-buffer
+	return r.tc.Cursor() >= len(r.filtered)-buffer
 }
 
 func (r *ResourceBrowser) loadNextPage() tea.Msg {

--- a/internal/view/resource_browser_nav.go
+++ b/internal/view/resource_browser_nav.go
@@ -16,7 +16,7 @@ func (r *ResourceBrowser) handleNavigation(key string) (tea.Model, tea.Cmd) {
 		return nil, nil
 	}
 
-	ctx, resource := r.contextForResource(r.filtered[r.table.Cursor()])
+	ctx, resource := r.contextForResource(r.filtered[r.tc.Cursor()])
 
 	helper := &NavigationHelper{
 		Ctx:      ctx,
@@ -54,6 +54,10 @@ func (r *ResourceBrowser) cycleResourceType(delta int) {
 
 // StatusLine implements View interface
 func (r *ResourceBrowser) StatusLine() string {
+	if r.filterActive {
+		return fmt.Sprintf("/%s • %d/%d items • Esc:done Enter:apply", r.filterInput.Value(), len(r.filtered), len(r.resources))
+	}
+
 	total := len(r.resources)
 	shown := len(r.filtered)
 	hasActions := len(action.Global.Get(r.service, r.resourceType)) > 0
@@ -168,6 +172,6 @@ func (r *ResourceBrowser) getNavigationShortcuts() string {
 	}
 
 	helper := &NavigationHelper{Renderer: r.renderer}
-	resource := dao.UnwrapResource(r.filtered[r.table.Cursor()])
+	resource := dao.UnwrapResource(r.filtered[r.tc.Cursor()])
 	return helper.FormatShortcuts(resource)
 }

--- a/internal/view/resource_browser_test.go
+++ b/internal/view/resource_browser_test.go
@@ -158,13 +158,13 @@ func TestResourceBrowserMouseHover(t *testing.T) {
 	browser.applyFilter()
 	browser.buildTable()
 
-	initialCursor := browser.table.Cursor()
+	initialCursor := browser.Cursor()
 
 	// Simulate mouse motion
 	motionMsg := tea.MouseMotionMsg{X: 30, Y: 10}
 	browser.Update(motionMsg)
 
-	t.Logf("Cursor after hover: %d (was %d)", browser.table.Cursor(), initialCursor)
+	t.Logf("Cursor after hover: %d (was %d)", browser.Cursor(), initialCursor)
 }
 
 func TestResourceBrowserMouseClick(t *testing.T) {
@@ -210,7 +210,7 @@ func TestResourceBrowserMarkUnmark(t *testing.T) {
 	}
 
 	// Mark first resource
-	browser.table.SetCursor(0)
+	browser.SetCursor(0)
 	mMsg := tea.KeyPressMsg{Code: 'm'}
 	browser.Update(mMsg)
 
@@ -229,9 +229,9 @@ func TestResourceBrowserMarkUnmark(t *testing.T) {
 	}
 
 	// Mark first, then mark second (should replace)
-	browser.table.SetCursor(0)
+	browser.SetCursor(0)
 	browser.Update(mMsg)
-	browser.table.SetCursor(1)
+	browser.SetCursor(1)
 	browser.Update(mMsg)
 
 	if browser.markedResource == nil {
@@ -259,7 +259,7 @@ func TestResourceBrowserMarkClearedOnResourceTypeSwitch(t *testing.T) {
 	browser.applyFilter()
 	browser.buildTable()
 
-	browser.table.SetCursor(0)
+	browser.SetCursor(0)
 	mMsg := tea.KeyPressMsg{Code: 'm'}
 	browser.Update(mMsg)
 
@@ -281,7 +281,7 @@ func TestResourceBrowserMarkClearedOnResourceTypeSwitch(t *testing.T) {
 	}
 	browser.applyFilter()
 	browser.buildTable()
-	browser.table.SetCursor(0)
+	browser.SetCursor(0)
 	browser.Update(mMsg)
 
 	if browser.markedResource == nil {
@@ -314,7 +314,7 @@ func TestResourceBrowserMarkClearedOnFilter(t *testing.T) {
 	browser.buildTable()
 
 	// Mark the first resource
-	browser.table.SetCursor(0)
+	browser.SetCursor(0)
 	mMsg := tea.KeyPressMsg{Code: 'm'}
 	browser.Update(mMsg)
 
@@ -358,7 +358,7 @@ func TestResourceBrowserDiffHintVisibility(t *testing.T) {
 	}
 
 	// Mark a resource: should show "d:diff"
-	browser.table.SetCursor(0)
+	browser.SetCursor(0)
 	mMsg := tea.KeyPressMsg{Code: 'm'}
 	browser.Update(mMsg)
 
@@ -389,7 +389,7 @@ func TestResourceBrowserMarkColumnRendering(t *testing.T) {
 		t.Error("Expected non-empty view")
 	}
 
-	browser.table.SetCursor(0)
+	browser.SetCursor(0)
 	mMsg := tea.KeyPressMsg{Code: 'm'}
 	browser.Update(mMsg)
 
@@ -414,7 +414,7 @@ func TestResourceBrowserEscClearsMark(t *testing.T) {
 	browser.buildTable()
 
 	// Mark a resource
-	browser.table.SetCursor(0)
+	browser.SetCursor(0)
 	mMsg := tea.KeyPressMsg{Code: 'm'}
 	browser.Update(mMsg)
 
@@ -450,14 +450,14 @@ func TestResourceBrowserDiffNavigation(t *testing.T) {
 	browser.applyFilter()
 	browser.buildTable()
 
-	browser.table.SetCursor(0)
+	browser.SetCursor(0)
 	browser.Update(tea.KeyPressMsg{Code: 'm'})
 
 	if browser.markedResource == nil {
 		t.Fatal("Expected resource to be marked")
 	}
 
-	browser.table.SetCursor(1)
+	browser.SetCursor(1)
 	_, cmd := browser.Update(tea.KeyPressMsg{Code: 'd'})
 
 	if cmd == nil {
@@ -619,7 +619,7 @@ func TestResourceBrowserCopyID(t *testing.T) {
 	}
 	browser.applyFilter()
 	browser.buildTable()
-	browser.table.SetCursor(0)
+	browser.SetCursor(0)
 
 	_, cmd := browser.Update(tea.KeyPressMsg{Code: 'y'})
 	if cmd == nil {
@@ -645,7 +645,7 @@ func TestResourceBrowserCopyARN(t *testing.T) {
 	}
 	browser.applyFilter()
 	browser.buildTable()
-	browser.table.SetCursor(0)
+	browser.SetCursor(0)
 
 	_, cmd := browser.Update(tea.KeyPressMsg{Code: 'Y'})
 	if cmd == nil {
@@ -666,7 +666,7 @@ func TestResourceBrowserCopyARNNoARN(t *testing.T) {
 	}
 	browser.applyFilter()
 	browser.buildTable()
-	browser.table.SetCursor(0)
+	browser.SetCursor(0)
 
 	_, cmd := browser.Update(tea.KeyPressMsg{Code: 'Y'})
 	if cmd == nil {

--- a/internal/view/resource_browser_update.go
+++ b/internal/view/resource_browser_update.go
@@ -129,8 +129,8 @@ func (r *ResourceBrowser) handleDiffMsg(msg DiffMsg) (tea.Model, tea.Cmd) {
 	}
 
 	if msg.LeftName == "" {
-		if len(r.filtered) > 0 && r.table.Cursor() < len(r.filtered) {
-			leftRes = r.filtered[r.table.Cursor()]
+		if len(r.filtered) > 0 && r.tc.Cursor() < len(r.filtered) {
+			leftRes = r.filtered[r.tc.Cursor()]
 		}
 	} else {
 		for _, res := range r.filtered {

--- a/internal/view/service_browser.go
+++ b/internal/view/service_browser.go
@@ -2,6 +2,7 @@ package view
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"charm.land/bubbles/v2/textinput"
@@ -88,14 +89,8 @@ func newServiceBrowserStyles() serviceBrowserStyles {
 			Bold(true).
 			MarginTop(1).
 			MarginBottom(0),
-		cell: lipgloss.NewStyle().
-			Width(cellWidth).
-			Height(cellHeight).
-			Padding(0, 1),
-		cellSelected: ui.SelectedStyle().
-			Width(cellWidth).
-			Height(cellHeight).
-			Padding(0, 1),
+		cell:          ui.CellStyle(cellWidth, cellHeight),
+		cellSelected:  ui.SelectedStyle().Width(cellWidth).Height(cellHeight).Padding(0, 1),
 		serviceName:   ui.TextStyle().Bold(true),
 		serviceNameSe: ui.TitleStyle(),
 		aliases:       ui.DimStyle(),
@@ -177,6 +172,10 @@ func (s *ServiceBrowser) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case RefreshMsg:
 		return s, s.loadServices
+	case ThemeChangedMsg:
+		s.styles = newServiceBrowserStyles()
+		s.headerPanel.ReloadStyles()
+		return s, nil
 
 	case tea.KeyPressMsg:
 		if s.filterActive {
@@ -606,12 +605,12 @@ func (s *ServiceBrowser) SetSize(width, height int) tea.Cmd {
 // StatusLine implements View
 func (s *ServiceBrowser) StatusLine() string {
 	if s.filterActive {
-		return "type to filter • enter:confirm • esc:cancel"
+		return fmt.Sprintf("/%s • %d services • Esc:done Enter:apply", s.filterInput.Value(), len(s.flatItems))
 	}
 	if s.filterText != "" {
-		return "~:home • c:clear • enter:select • ?:help"
+		return fmt.Sprintf("/%s • %d services • ~:home c:clear enter:select ?:help", s.filterText, len(s.flatItems))
 	}
-	return "~:home • /:filter • enter:select • ?:help"
+	return "~:home /:filter enter:select ?:help"
 }
 
 // HasActiveInput implements InputCapture

--- a/internal/view/table_cursor.go
+++ b/internal/view/table_cursor.go
@@ -1,0 +1,85 @@
+package view
+
+// TableCursor manages cursor position and scroll offset for table-based views.
+// Embed this struct in views that display scrollable tables.
+type TableCursor struct {
+	cursor       int
+	scrollOffset int
+	tableHeight  int
+}
+
+// Cursor returns the current cursor position.
+func (c *TableCursor) Cursor() int {
+	return c.cursor
+}
+
+// SetCursor sets the cursor position, clamping to valid range [0, dataLen-1].
+func (c *TableCursor) SetCursor(n int, dataLen int) {
+	if dataLen == 0 {
+		c.cursor = 0
+		return
+	}
+	if n < 0 {
+		n = 0
+	}
+	if n >= dataLen {
+		n = dataLen - 1
+	}
+	c.cursor = n
+}
+
+// ScrollOffset returns the current scroll offset.
+func (c *TableCursor) ScrollOffset() int {
+	return c.scrollOffset
+}
+
+// TableHeight returns the current table height.
+func (c *TableCursor) TableHeight() int {
+	return c.tableHeight
+}
+
+// SetTableHeight sets the table height.
+func (c *TableCursor) SetTableHeight(h int) {
+	c.tableHeight = h
+}
+
+// UpdateScrollOffset adjusts scroll offset to keep cursor visible.
+func (c *TableCursor) UpdateScrollOffset(dataLen int) {
+	visibleRows := c.tableHeight - 2
+	if visibleRows < 1 {
+		visibleRows = 1
+	}
+
+	if c.cursor < c.scrollOffset {
+		c.scrollOffset = c.cursor
+	} else if c.cursor >= c.scrollOffset+visibleRows {
+		c.scrollOffset = c.cursor - visibleRows + 1
+	}
+
+	c.clampScrollOffset(dataLen, visibleRows)
+}
+
+// AdjustScrollOffset adjusts scroll offset by delta (for mouse wheel).
+// Returns the new scroll offset.
+func (c *TableCursor) AdjustScrollOffset(delta int, dataLen int) {
+	visibleRows := c.tableHeight - 2
+	if visibleRows < 1 {
+		visibleRows = 1
+	}
+
+	c.scrollOffset += delta
+	c.clampScrollOffset(dataLen, visibleRows)
+}
+
+func (c *TableCursor) clampScrollOffset(dataLen int, visibleRows int) {
+	maxOffset := dataLen - visibleRows
+	if maxOffset < 0 {
+		maxOffset = 0
+	}
+	if c.scrollOffset > maxOffset {
+		c.scrollOffset = maxOffset
+	}
+	if c.scrollOffset < 0 {
+		c.scrollOffset = 0
+	}
+}

--- a/internal/view/table_style.go
+++ b/internal/view/table_style.go
@@ -1,0 +1,50 @@
+package view
+
+import (
+	"charm.land/lipgloss/v2"
+	"charm.land/lipgloss/v2/table"
+
+	"github.com/clawscli/claws/internal/ui"
+)
+
+// NewTableStyleFunc returns a StyleFunc for lipgloss/table that applies
+// consistent styling: header row with TableHeader colors, selected row
+// with Selection colors, and normal rows with Text color.
+// Pre-computes styles for each column to avoid per-cell allocations.
+func NewTableStyleFunc(widths []int, cursor int) func(row, col int) lipgloss.Style {
+	th := ui.Current()
+	numCols := len(widths)
+
+	headerStyles := make([]lipgloss.Style, numCols)
+	selectedStyles := make([]lipgloss.Style, numCols)
+	normalStyles := make([]lipgloss.Style, numCols)
+
+	for col, w := range widths {
+		base := lipgloss.NewStyle().Width(w)
+		if col == 0 {
+			base = base.PaddingLeft(1)
+		}
+		headerStyles[col] = base.Bold(true).Foreground(th.TableHeaderText).Background(th.TableHeader)
+		selectedStyles[col] = base.Foreground(th.SelectionText).Background(th.Selection)
+		normalStyles[col] = base.Foreground(th.Text)
+	}
+
+	return func(row, col int) lipgloss.Style {
+		if col >= numCols {
+			return ui.NoStyle()
+		}
+		switch {
+		case row == table.HeaderRow:
+			return headerStyles[col]
+		case row == cursor:
+			return selectedStyles[col]
+		default:
+			return normalStyles[col]
+		}
+	}
+}
+
+// TableBorderStyle returns a style for table borders using the current theme.
+func TableBorderStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(ui.Current().TableBorder)
+}

--- a/internal/view/view.go
+++ b/internal/view/view.go
@@ -64,6 +64,17 @@ type DataLoadedMsg struct {
 // RefreshMsg tells the view to reload its data
 type RefreshMsg struct{}
 
+// ThemeChangedMsg tells views to reload their cached styles
+type ThemeChangedMsg struct{}
+
+type ThemeChangeMsg struct {
+	Name string
+}
+
+type PersistenceChangeMsg struct {
+	Enabled bool
+}
+
 // SortMsg tells the current view to sort by the specified column
 type SortMsg struct {
 	Column    string // Column name to sort by (empty to clear sort)

--- a/internal/view/view_test.go
+++ b/internal/view/view_test.go
@@ -29,12 +29,14 @@ type mockRenderer struct {
 	detail string
 }
 
-func (m *mockRenderer) ServiceName() string                                     { return "test" }
-func (m *mockRenderer) ResourceType() string                                    { return "items" }
-func (m *mockRenderer) Columns() []render.Column                                { return nil }
-func (m *mockRenderer) RenderRow(r dao.Resource, cols []render.Column) []string { return nil }
-func (m *mockRenderer) RenderDetail(r dao.Resource) string                      { return m.detail }
-func (m *mockRenderer) RenderSummary(r dao.Resource) []render.SummaryField      { return nil }
+func (m *mockRenderer) ServiceName() string      { return "test" }
+func (m *mockRenderer) ResourceType() string     { return "items" }
+func (m *mockRenderer) Columns() []render.Column { return []render.Column{{Name: "NAME", Width: 20}} }
+func (m *mockRenderer) RenderRow(r dao.Resource, cols []render.Column) []string {
+	return []string{r.GetName()}
+}
+func (m *mockRenderer) RenderDetail(r dao.Resource) string                 { return m.detail }
+func (m *mockRenderer) RenderSummary(r dao.Resource) []render.SummaryField { return nil }
 
 // IsEscKey tests
 


### PR DESCRIPTION
## Release v0.8.0

### New Features
- **Theming Support** - 6 preset themes: dark, light, nord, dracula, gruvbox, catppuccin
- **`:theme` command** - Switch themes at runtime (persisted when autosave enabled)
- **`--theme` CLI flag** - Set theme for session
- **`:autosave` command** - Toggle config persistence on/off
- **`--autosave/--no-autosave` CLI flags** - Control config persistence

### Improvements
- Migrate to lipgloss/v2/table for proper cell theming
- YAML config patching preserves comments and unknown keys
- Thread-safe theme access with RWMutex
- Multi-profile support in config (`startup.profiles` array)

### Breaking Changes ⚠️

| Before | After | Migration |
|--------|-------|-----------|
| `persistence.enabled` | `autosave.enabled` | Auto-read old key, new saves use `autosave` |
| `--persist` / `--no-persist` | `--autosave` / `--no-autosave` | Update scripts/aliases |
| `startup.profile` (string) | `startup.profiles` (array) | Old format still readable |

### Closes
- #96 Theming support

---
**Note**: develop → main PRs use **merge commit** (not squash)