### PR TITLE
docs: simplify homebrew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ A terminal UI for AWS resource management
 ### Homebrew (macOS/Linux)
 
 ```bash
-brew tap clawscli/tap
-brew install --cask claws
+brew install --cask clawscli/tap/claws
 ```
 
 ### Install Script (macOS/Linux)


### PR DESCRIPTION
## Summary
- Simplify Homebrew install from 2 commands to 1
- `brew install --cask clawscli/tap/claws` (auto-taps)