### PR TITLE
Add AI chat overlay with Bedrock Converse API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -97,6 +97,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.16 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.16 // indirect
+	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.47.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.16 // indirect

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.52.2 h1:jrOALh0fIx8kUfesQS4
 github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.52.2/go.mod h1:hRzcNxU8BOG5ijgeMDLyw0sx4fBOxrjPDB/DnDK6X1M=
 github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.15.1 h1:BJmfQWd/3kjWCw3zkS3lSZ9uVwo9jsDGfW8g4EG2xbY=
 github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.15.1/go.mod h1:3zWDBnJEUh72XdC7iEqdCSwPwDuveVsKTmtThuGwC2s=
+github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.47.1 h1:xryaVPvLLcCf7Y/4beWjOcWxiftorB/KDjtiYORVSNo=
+github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.47.1/go.mod h1:ckSglleOJ2avj81L6vBb70nK51cnhTwvVK1SkLgFtj4=
 github.com/aws/aws-sdk-go-v2/service/budgets v1.42.3 h1:SWmlAqhAeh9ByGn56CLqJEEFwd1tsDM1t9ojTcxpnvo=
 github.com/aws/aws-sdk-go-v2/service/budgets v1.42.3/go.mod h1:MBllv8Mjt8gp2rBU+iA5L6QabvS5L00LSru/ICHld7M=
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.71.4 h1:9dwMueqbHIp0KTw2Zt0rhVobiPMlAI8UgyxiaBzM+1E=

--- a/internal/ai/bedrock.go
+++ b/internal/ai/bedrock.go
@@ -1,0 +1,314 @@
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/document"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+
+	appaws "github.com/clawscli/claws/internal/aws"
+)
+
+const DefaultModel = "global.anthropic.claude-haiku-4-5-20251001-v1:0"
+
+type Role string
+
+const (
+	RoleUser      Role = "user"
+	RoleAssistant Role = "assistant"
+)
+
+type Message struct {
+	Role    Role   `json:"role"`
+	Content string `json:"content"`
+}
+
+type ToolCall struct {
+	ID    string         `json:"id"`
+	Name  string         `json:"name"`
+	Input map[string]any `json:"input"`
+}
+
+type ToolResult struct {
+	ID      string `json:"id"`
+	Content string `json:"content"`
+	IsError bool   `json:"is_error,omitempty"`
+}
+
+type StreamEvent struct {
+	Type      string
+	Text      string
+	ToolCalls []ToolCall
+	Error     error
+}
+
+type Tool struct {
+	Name        string
+	Description string
+	InputSchema map[string]any
+}
+
+type Client struct {
+	client  *bedrockruntime.Client
+	modelID string
+	tools   []Tool
+}
+
+type ClientOption func(*Client)
+
+func WithModel(modelID string) ClientOption {
+	return func(c *Client) {
+		c.modelID = modelID
+	}
+}
+
+func WithTools(tools []Tool) ClientOption {
+	return func(c *Client) {
+		c.tools = tools
+	}
+}
+
+func NewClient(ctx context.Context, opts ...ClientOption) (*Client, error) {
+	cfg, err := appaws.NewConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("load aws config: %w", err)
+	}
+
+	c := &Client{
+		client:  bedrockruntime.NewFromConfig(cfg),
+		modelID: DefaultModel,
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c, nil
+}
+
+func (c *Client) Converse(ctx context.Context, messages []Message, systemPrompt string) (*ConversationResult, error) {
+	input := c.buildConverseInput(messages, systemPrompt)
+
+	output, err := c.client.Converse(ctx, input)
+	if err != nil {
+		return nil, fmt.Errorf("converse: %w", err)
+	}
+
+	return c.parseConverseOutput(output)
+}
+
+func (c *Client) ConverseStream(ctx context.Context, messages []Message, systemPrompt string) (<-chan StreamEvent, error) {
+	input := c.buildConverseStreamInput(messages, systemPrompt)
+
+	output, err := c.client.ConverseStream(ctx, input)
+	if err != nil {
+		return nil, fmt.Errorf("converse stream: %w", err)
+	}
+
+	events := make(chan StreamEvent, 10)
+	go c.processStream(output, events)
+
+	return events, nil
+}
+
+type ConversationResult struct {
+	Message    string
+	ToolCalls  []ToolCall
+	StopReason string
+}
+
+func (c *Client) buildConverseInput(messages []Message, systemPrompt string) *bedrockruntime.ConverseInput {
+	input := &bedrockruntime.ConverseInput{
+		ModelId:  aws.String(c.modelID),
+		Messages: c.convertMessages(messages),
+	}
+
+	if systemPrompt != "" {
+		input.System = []types.SystemContentBlock{
+			&types.SystemContentBlockMemberText{Value: systemPrompt},
+		}
+	}
+
+	if len(c.tools) > 0 {
+		input.ToolConfig = c.buildToolConfig()
+	}
+
+	return input
+}
+
+func (c *Client) buildConverseStreamInput(messages []Message, systemPrompt string) *bedrockruntime.ConverseStreamInput {
+	input := &bedrockruntime.ConverseStreamInput{
+		ModelId:  aws.String(c.modelID),
+		Messages: c.convertMessages(messages),
+	}
+
+	if systemPrompt != "" {
+		input.System = []types.SystemContentBlock{
+			&types.SystemContentBlockMemberText{Value: systemPrompt},
+		}
+	}
+
+	if len(c.tools) > 0 {
+		input.ToolConfig = c.buildToolConfig()
+	}
+
+	return input
+}
+
+func (c *Client) convertMessages(messages []Message) []types.Message {
+	result := make([]types.Message, 0, len(messages))
+
+	for _, msg := range messages {
+		result = append(result, types.Message{
+			Role: types.ConversationRole(msg.Role),
+			Content: []types.ContentBlock{
+				&types.ContentBlockMemberText{Value: msg.Content},
+			},
+		})
+	}
+
+	return result
+}
+
+func (c *Client) buildToolConfig() *types.ToolConfiguration {
+	toolDefs := make([]types.Tool, 0, len(c.tools))
+
+	for _, t := range c.tools {
+		toolDefs = append(toolDefs, &types.ToolMemberToolSpec{
+			Value: types.ToolSpecification{
+				Name:        aws.String(t.Name),
+				Description: aws.String(t.Description),
+				InputSchema: &types.ToolInputSchemaMemberJson{
+					Value: document.NewLazyDocument(t.InputSchema),
+				},
+			},
+		})
+	}
+
+	return &types.ToolConfiguration{
+		Tools: toolDefs,
+	}
+}
+
+func (c *Client) parseConverseOutput(output *bedrockruntime.ConverseOutput) (*ConversationResult, error) {
+	result := &ConversationResult{}
+
+	if output.StopReason != "" {
+		result.StopReason = string(output.StopReason)
+	}
+
+	if output.Output == nil {
+		return result, nil
+	}
+
+	msg, ok := output.Output.(*types.ConverseOutputMemberMessage)
+	if !ok {
+		return result, nil
+	}
+
+	for _, block := range msg.Value.Content {
+		switch b := block.(type) {
+		case *types.ContentBlockMemberText:
+			result.Message += b.Value
+		case *types.ContentBlockMemberToolUse:
+			inputBytes, _ := json.Marshal(b.Value.Input)
+			var inputMap map[string]any
+			_ = json.Unmarshal(inputBytes, &inputMap)
+
+			result.ToolCalls = append(result.ToolCalls, ToolCall{
+				ID:    aws.ToString(b.Value.ToolUseId),
+				Name:  aws.ToString(b.Value.Name),
+				Input: inputMap,
+			})
+		}
+	}
+
+	return result, nil
+}
+
+func (c *Client) processStream(output *bedrockruntime.ConverseStreamOutput, events chan<- StreamEvent) {
+	defer close(events)
+
+	stream := output.GetStream()
+	defer func() { _ = stream.Close() }()
+
+	var currentToolCall *ToolCall
+	var toolInputJSON string
+
+	for event := range stream.Events() {
+		switch e := event.(type) {
+		case *types.ConverseStreamOutputMemberContentBlockStart:
+			if toolUse, ok := e.Value.Start.(*types.ContentBlockStartMemberToolUse); ok {
+				currentToolCall = &ToolCall{
+					ID:   aws.ToString(toolUse.Value.ToolUseId),
+					Name: aws.ToString(toolUse.Value.Name),
+				}
+				toolInputJSON = ""
+			}
+
+		case *types.ConverseStreamOutputMemberContentBlockDelta:
+			switch delta := e.Value.Delta.(type) {
+			case *types.ContentBlockDeltaMemberText:
+				events <- StreamEvent{Type: "text", Text: delta.Value}
+			case *types.ContentBlockDeltaMemberToolUse:
+				if delta.Value.Input != nil {
+					toolInputJSON += *delta.Value.Input
+				}
+			}
+
+		case *types.ConverseStreamOutputMemberContentBlockStop:
+			if currentToolCall != nil {
+				var inputMap map[string]any
+				_ = json.Unmarshal([]byte(toolInputJSON), &inputMap)
+				currentToolCall.Input = inputMap
+
+				events <- StreamEvent{
+					Type:      "tool_use",
+					ToolCalls: []ToolCall{*currentToolCall},
+				}
+				currentToolCall = nil
+			}
+
+		case *types.ConverseStreamOutputMemberMessageStop:
+			events <- StreamEvent{Type: "done"}
+			return
+		}
+	}
+
+	if err := stream.Err(); err != nil {
+		events <- StreamEvent{Type: "error", Error: err}
+	}
+}
+
+func (c *Client) AddToolResultMessages(messages []Message, toolCalls []ToolCall, results []ToolResult) []Message {
+	assistantContent := ""
+	for _, tc := range toolCalls {
+		inputJSON, _ := json.Marshal(tc.Input)
+		assistantContent += fmt.Sprintf("[Tool: %s]\n%s\n", tc.Name, string(inputJSON))
+	}
+
+	messages = append(messages, Message{
+		Role:    RoleAssistant,
+		Content: assistantContent,
+	})
+
+	var resultContent string
+	for _, r := range results {
+		if r.IsError {
+			resultContent += fmt.Sprintf("[Tool Result - Error]\n%s\n", r.Content)
+		} else {
+			resultContent += fmt.Sprintf("[Tool Result]\n%s\n", r.Content)
+		}
+	}
+
+	messages = append(messages, Message{
+		Role:    RoleUser,
+		Content: resultContent,
+	})
+
+	return messages
+}

--- a/internal/ai/session.go
+++ b/internal/ai/session.go
@@ -1,0 +1,251 @@
+package ai
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/clawscli/claws/internal/config"
+)
+
+const (
+	DefaultMaxSessions = 10
+	sessionDir         = "chat/sessions"
+	currentSessionFile = "chat/current.json"
+)
+
+type Session struct {
+	ID        string    `json:"id"`
+	StartedAt time.Time `json:"started_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+	Messages  []Message `json:"messages"`
+	Context   *Context  `json:"context,omitempty"`
+}
+
+type Context struct {
+	Service      string `json:"service,omitempty"`
+	ResourceType string `json:"resource_type,omitempty"`
+	ResourceID   string `json:"resource_id,omitempty"`
+	ResourceName string `json:"resource_name,omitempty"`
+	LogGroup     string `json:"log_group,omitempty"`
+}
+
+type SessionManager struct {
+	maxSessions int
+	currentID   string
+}
+
+func NewSessionManager(maxSessions int) *SessionManager {
+	if maxSessions <= 0 {
+		maxSessions = DefaultMaxSessions
+	}
+	return &SessionManager{
+		maxSessions: maxSessions,
+	}
+}
+
+func (m *SessionManager) sessionsDir() (string, error) {
+	dir, err := config.ConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, sessionDir), nil
+}
+
+func (m *SessionManager) currentPath() (string, error) {
+	dir, err := config.ConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, currentSessionFile), nil
+}
+
+func (m *SessionManager) NewSession(ctx *Context) (*Session, error) {
+	session := &Session{
+		ID:        generateSessionID(),
+		StartedAt: time.Now(),
+		UpdatedAt: time.Now(),
+		Messages:  []Message{},
+		Context:   ctx,
+	}
+
+	if err := m.saveSession(session); err != nil {
+		return nil, err
+	}
+
+	m.currentID = session.ID
+
+	if err := m.pruneOldSessions(); err != nil {
+		return session, nil
+	}
+
+	return session, nil
+}
+
+func (m *SessionManager) CurrentSession() (*Session, error) {
+	if m.currentID == "" {
+		path, err := m.currentPath()
+		if err != nil {
+			return nil, err
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil, nil
+			}
+			return nil, err
+		}
+
+		var current struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal(data, &current); err != nil {
+			return nil, err
+		}
+		m.currentID = current.ID
+	}
+
+	if m.currentID == "" {
+		return nil, nil
+	}
+
+	return m.LoadSession(m.currentID)
+}
+
+func (m *SessionManager) LoadSession(id string) (*Session, error) {
+	dir, err := m.sessionsDir()
+	if err != nil {
+		return nil, err
+	}
+
+	path := filepath.Join(dir, id+".json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var session Session
+	if err := json.Unmarshal(data, &session); err != nil {
+		return nil, err
+	}
+
+	return &session, nil
+}
+
+func (m *SessionManager) SaveMessages(session *Session) error {
+	session.UpdatedAt = time.Now()
+	return m.saveSession(session)
+}
+
+func (m *SessionManager) AddMessage(session *Session, msg Message) error {
+	session.Messages = append(session.Messages, msg)
+	return m.SaveMessages(session)
+}
+
+func (m *SessionManager) ListSessions() ([]Session, error) {
+	dir, err := m.sessionsDir()
+	if err != nil {
+		return nil, err
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var sessions []Session
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+
+		id := entry.Name()[:len(entry.Name())-5]
+		session, err := m.LoadSession(id)
+		if err != nil {
+			continue
+		}
+		sessions = append(sessions, *session)
+	}
+
+	sort.Slice(sessions, func(i, j int) bool {
+		return sessions[i].UpdatedAt.After(sessions[j].UpdatedAt)
+	})
+
+	return sessions, nil
+}
+
+func (m *SessionManager) saveSession(session *Session) error {
+	dir, err := m.sessionsDir()
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+
+	path := filepath.Join(dir, session.ID+".json")
+	data, err := json.MarshalIndent(session, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return err
+	}
+
+	return m.saveCurrentID(session.ID)
+}
+
+func (m *SessionManager) saveCurrentID(id string) error {
+	path, err := m.currentPath()
+	if err != nil {
+		return err
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+
+	data, _ := json.Marshal(struct {
+		ID string `json:"id"`
+	}{ID: id})
+
+	return os.WriteFile(path, data, 0644)
+}
+
+func (m *SessionManager) pruneOldSessions() error {
+	sessions, err := m.ListSessions()
+	if err != nil {
+		return err
+	}
+
+	if len(sessions) <= m.maxSessions {
+		return nil
+	}
+
+	dir, err := m.sessionsDir()
+	if err != nil {
+		return err
+	}
+
+	for i := m.maxSessions; i < len(sessions); i++ {
+		path := filepath.Join(dir, sessions[i].ID+".json")
+		_ = os.Remove(path)
+	}
+
+	return nil
+}
+
+func generateSessionID() string {
+	now := time.Now()
+	return fmt.Sprintf("%s-%d", now.Format("2006-01-02"), now.UnixNano()%1000000)
+}

--- a/internal/ai/tools.go
+++ b/internal/ai/tools.go
@@ -1,0 +1,334 @@
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+
+	appaws "github.com/clawscli/claws/internal/aws"
+	"github.com/clawscli/claws/internal/dao"
+	"github.com/clawscli/claws/internal/registry"
+)
+
+type ToolExecutor struct {
+	registry *registry.Registry
+	cwClient *cloudwatchlogs.Client
+}
+
+func NewToolExecutor(ctx context.Context, reg *registry.Registry) (*ToolExecutor, error) {
+	cfg, err := appaws.NewConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("load aws config: %w", err)
+	}
+
+	return &ToolExecutor{
+		registry: reg,
+		cwClient: cloudwatchlogs.NewFromConfig(cfg),
+	}, nil
+}
+
+func (e *ToolExecutor) Tools() []Tool {
+	return []Tool{
+		{
+			Name:        "list_services",
+			Description: "List all available AWS services",
+			InputSchema: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{},
+			},
+		},
+		{
+			Name:        "list_resources",
+			Description: "List resource types available for a specific AWS service",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"service": map[string]any{
+						"type":        "string",
+						"description": "AWS service name (e.g., ec2, lambda, s3)",
+					},
+				},
+				"required": []string{"service"},
+			},
+		},
+		{
+			Name:        "query_resources",
+			Description: "List AWS resources of a specific type",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"service": map[string]any{
+						"type":        "string",
+						"description": "AWS service name (e.g., ec2, lambda)",
+					},
+					"resource_type": map[string]any{
+						"type":        "string",
+						"description": "Resource type (e.g., instances, functions)",
+					},
+				},
+				"required": []string{"service", "resource_type"},
+			},
+		},
+		{
+			Name:        "get_resource_detail",
+			Description: "Get detailed information about a specific AWS resource",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"service": map[string]any{
+						"type":        "string",
+						"description": "AWS service name",
+					},
+					"resource_type": map[string]any{
+						"type":        "string",
+						"description": "Resource type",
+					},
+					"id": map[string]any{
+						"type":        "string",
+						"description": "Resource ID",
+					},
+				},
+				"required": []string{"service", "resource_type", "id"},
+			},
+		},
+		{
+			Name:        "tail_logs",
+			Description: "Fetch recent CloudWatch logs from a log group",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"log_group": map[string]any{
+						"type":        "string",
+						"description": "CloudWatch log group name (e.g., /aws/lambda/my-function)",
+					},
+					"filter": map[string]any{
+						"type":        "string",
+						"description": "Optional filter pattern for log messages",
+					},
+					"since": map[string]any{
+						"type":        "string",
+						"description": "Time range (e.g., 5m, 1h, 24h). Default: 15m",
+					},
+					"limit": map[string]any{
+						"type":        "integer",
+						"description": "Maximum number of log events. Default: 100",
+					},
+				},
+				"required": []string{"log_group"},
+			},
+		},
+		{
+			Name:        "search_aws_docs",
+			Description: "Search AWS documentation for information",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"query": map[string]any{
+						"type":        "string",
+						"description": "Search query for AWS documentation",
+					},
+				},
+				"required": []string{"query"},
+			},
+		},
+	}
+}
+
+func (e *ToolExecutor) Execute(ctx context.Context, call ToolCall) ToolResult {
+	var content string
+	var isError bool
+
+	switch call.Name {
+	case "list_services":
+		content = e.listServices()
+	case "list_resources":
+		service, _ := call.Input["service"].(string)
+		content = e.listResources(service)
+	case "query_resources":
+		service, _ := call.Input["service"].(string)
+		resourceType, _ := call.Input["resource_type"].(string)
+		content, isError = e.queryResources(ctx, service, resourceType)
+	case "get_resource_detail":
+		service, _ := call.Input["service"].(string)
+		resourceType, _ := call.Input["resource_type"].(string)
+		id, _ := call.Input["id"].(string)
+		content, isError = e.getResourceDetail(ctx, service, resourceType, id)
+	case "tail_logs":
+		logGroup, _ := call.Input["log_group"].(string)
+		filter, _ := call.Input["filter"].(string)
+		since, _ := call.Input["since"].(string)
+		limit, _ := call.Input["limit"].(float64)
+		content, isError = e.tailLogs(ctx, logGroup, filter, since, int(limit))
+	case "search_aws_docs":
+		query, _ := call.Input["query"].(string)
+		content = e.searchDocs(query)
+	default:
+		content = fmt.Sprintf("Unknown tool: %s", call.Name)
+		isError = true
+	}
+
+	return ToolResult{
+		ID:      call.ID,
+		Content: content,
+		IsError: isError,
+	}
+}
+
+func (e *ToolExecutor) listServices() string {
+	categories := e.registry.ListServicesByCategory()
+	var result string
+
+	for _, cat := range categories {
+		result += fmt.Sprintf("\n## %s\n", cat.Name)
+		for _, svc := range cat.Services {
+			displayName := e.registry.GetDisplayName(svc)
+			resources := e.registry.ListResources(svc)
+			result += fmt.Sprintf("- %s (%s): %d resource types\n", displayName, svc, len(resources))
+		}
+	}
+
+	return result
+}
+
+func (e *ToolExecutor) listResources(service string) string {
+	resources := e.registry.ListResources(service)
+	if len(resources) == 0 {
+		return fmt.Sprintf("No resources found for service: %s", service)
+	}
+
+	displayName := e.registry.GetDisplayName(service)
+	result := fmt.Sprintf("Resource types for %s (%s):\n", displayName, service)
+	for _, r := range resources {
+		result += fmt.Sprintf("- %s\n", r)
+	}
+	return result
+}
+
+func (e *ToolExecutor) queryResources(ctx context.Context, service, resourceType string) (string, bool) {
+	d, err := e.registry.GetDAO(ctx, service, resourceType)
+	if err != nil {
+		return fmt.Sprintf("Error getting DAO: %v", err), true
+	}
+
+	resources, err := d.List(ctx)
+	if err != nil {
+		return fmt.Sprintf("Error listing resources: %v", err), true
+	}
+
+	if len(resources) == 0 {
+		return fmt.Sprintf("No %s/%s resources found", service, resourceType), false
+	}
+
+	result := fmt.Sprintf("Found %d %s/%s resources:\n\n", len(resources), service, resourceType)
+	for i, r := range resources {
+		if i >= 50 {
+			result += fmt.Sprintf("\n... and %d more\n", len(resources)-50)
+			break
+		}
+		result += formatResourceSummary(r)
+	}
+
+	return result, false
+}
+
+func (e *ToolExecutor) getResourceDetail(ctx context.Context, service, resourceType, id string) (string, bool) {
+	d, err := e.registry.GetDAO(ctx, service, resourceType)
+	if err != nil {
+		return fmt.Sprintf("Error getting DAO: %v", err), true
+	}
+
+	resource, err := d.Get(ctx, id)
+	if err != nil {
+		return fmt.Sprintf("Error getting resource: %v", err), true
+	}
+
+	return formatResourceDetail(resource), false
+}
+
+func (e *ToolExecutor) tailLogs(ctx context.Context, logGroup, filter, since string, limit int) (string, bool) {
+	if limit <= 0 {
+		limit = 100
+	}
+	if limit > 500 {
+		limit = 500
+	}
+
+	startTime := time.Now().Add(-15 * time.Minute)
+	if since != "" {
+		if d, err := time.ParseDuration(since); err == nil {
+			startTime = time.Now().Add(-d)
+		}
+	}
+
+	input := &cloudwatchlogs.FilterLogEventsInput{
+		LogGroupName: aws.String(logGroup),
+		StartTime:    aws.Int64(startTime.UnixMilli()),
+		Limit:        aws.Int32(int32(limit)),
+	}
+
+	if filter != "" {
+		input.FilterPattern = aws.String(filter)
+	}
+
+	output, err := e.cwClient.FilterLogEvents(ctx, input)
+	if err != nil {
+		return fmt.Sprintf("Error fetching logs: %v", err), true
+	}
+
+	if len(output.Events) == 0 {
+		return fmt.Sprintf("No logs found in %s (since %s)", logGroup, since), false
+	}
+
+	result := fmt.Sprintf("Logs from %s (%d events):\n\n", logGroup, len(output.Events))
+	for _, event := range output.Events {
+		ts := time.UnixMilli(aws.ToInt64(event.Timestamp))
+		result += fmt.Sprintf("[%s] %s\n", ts.Format("15:04:05"), aws.ToString(event.Message))
+	}
+
+	return result, false
+}
+
+func (e *ToolExecutor) searchDocs(query string) string {
+	return fmt.Sprintf("Documentation search for '%s' is not yet implemented. Please check AWS documentation directly.", query)
+}
+
+func formatResourceSummary(r dao.Resource) string {
+	result := fmt.Sprintf("- ID: %s", r.GetID())
+	if name := r.GetName(); name != "" && name != r.GetID() {
+		result += fmt.Sprintf(", Name: %s", name)
+	}
+	result += "\n"
+	return result
+}
+
+func formatResourceDetail(r dao.Resource) string {
+	result := fmt.Sprintf("ID: %s\n", r.GetID())
+
+	if name := r.GetName(); name != "" {
+		result += fmt.Sprintf("Name: %s\n", name)
+	}
+
+	if arn := r.GetARN(); arn != "" {
+		result += fmt.Sprintf("ARN: %s\n", arn)
+	}
+
+	if tags := r.GetTags(); len(tags) > 0 {
+		result += "\nTags:\n"
+		for k, v := range tags {
+			result += fmt.Sprintf("  %s: %s\n", k, v)
+		}
+	}
+
+	if raw := r.Raw(); raw != nil {
+		data, err := json.MarshalIndent(raw, "", "  ")
+		if err == nil {
+			result += fmt.Sprintf("\nRaw Data:\n%s\n", string(data))
+		}
+	}
+
+	return result
+}

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -78,9 +78,13 @@ func (s StartupConfig) GetProfiles() []string {
 	return nil
 }
 
-// NavigationConfig controls navigation behavior.
 type NavigationConfig struct {
 	MaxStackSize int `yaml:"max_stack_size,omitempty"`
+}
+
+type AIConfig struct {
+	Model       string `yaml:"model,omitempty"`
+	MaxSessions int    `yaml:"max_sessions,omitempty"`
 }
 
 // ThemeConfig holds theme configuration.
@@ -134,6 +138,7 @@ type FileConfig struct {
 	Startup             StartupConfig     `yaml:"startup,omitempty"`
 	Theme               ThemeConfig       `yaml:"theme,omitempty"`
 	Navigation          NavigationConfig  `yaml:"navigation,omitempty"`
+	AI                  AIConfig          `yaml:"ai,omitempty"`
 }
 
 // Duration wraps time.Duration for YAML marshal/unmarshal as string (e.g., "5s", "30s")
@@ -360,6 +365,27 @@ func (c *FileConfig) GetStartupView() string {
 
 func (c *FileConfig) GetTheme() ThemeConfig {
 	return withRLock(&c.mu, func() ThemeConfig { return c.Theme })
+}
+
+const DefaultAIModel = "global.anthropic.claude-haiku-4-5-20251001-v1:0"
+const DefaultAIMaxSessions = 10
+
+func (c *FileConfig) GetAIModel() string {
+	return withRLock(&c.mu, func() string {
+		if c.AI.Model == "" {
+			return DefaultAIModel
+		}
+		return c.AI.Model
+	})
+}
+
+func (c *FileConfig) GetAIMaxSessions() int {
+	return withRLock(&c.mu, func() int {
+		if c.AI.MaxSessions <= 0 {
+			return DefaultAIMaxSessions
+		}
+		return c.AI.MaxSessions
+	})
 }
 
 func (c *FileConfig) SaveRegions(regions []string) error {

--- a/internal/view/chat_overlay.go
+++ b/internal/view/chat_overlay.go
@@ -1,0 +1,381 @@
+package view
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/clawscli/claws/internal/ai"
+	"github.com/clawscli/claws/internal/config"
+	"github.com/clawscli/claws/internal/registry"
+	"github.com/clawscli/claws/internal/ui"
+)
+
+type chatStyles struct {
+	title        lipgloss.Style
+	context      lipgloss.Style
+	userMsg      lipgloss.Style
+	assistantMsg lipgloss.Style
+	thinking     lipgloss.Style
+	input        lipgloss.Style
+}
+
+func newChatStyles() chatStyles {
+	t := ui.Current()
+	return chatStyles{
+		title:        lipgloss.NewStyle().Bold(true).Foreground(t.Primary),
+		context:      lipgloss.NewStyle().Foreground(t.TextDim).Italic(true),
+		userMsg:      lipgloss.NewStyle().Foreground(t.Text),
+		assistantMsg: lipgloss.NewStyle().Foreground(t.Secondary),
+		thinking:     lipgloss.NewStyle().Foreground(t.TextDim).Italic(true),
+		input:        lipgloss.NewStyle().BorderStyle(lipgloss.RoundedBorder()).BorderForeground(t.Border).Padding(0, 1),
+	}
+}
+
+type ChatOverlay struct {
+	ctx      context.Context
+	registry *registry.Registry
+	aiCtx    *ai.Context
+	styles   chatStyles
+
+	client   *ai.Client
+	executor *ai.ToolExecutor
+	session  *ai.Session
+	sessMgr  *ai.SessionManager
+
+	input textinput.Model
+	vp    ViewportState
+
+	messages     []chatMessage
+	streamingMsg string
+	isThinking   bool
+	err          error
+
+	width  int
+	height int
+}
+
+type chatMessage struct {
+	role    ai.Role
+	content string
+}
+
+type chatStreamMsg struct {
+	event ai.StreamEvent
+}
+
+type chatDoneMsg struct {
+	err error
+}
+
+type chatInitMsg struct {
+	client   *ai.Client
+	executor *ai.ToolExecutor
+	session  *ai.Session
+	err      error
+}
+
+func NewChatOverlay(ctx context.Context, reg *registry.Registry, aiCtx *ai.Context) *ChatOverlay {
+	maxSessions := config.File().GetAIMaxSessions()
+
+	ti := textinput.New()
+	ti.Placeholder = "Ask about AWS resources..."
+	ti.Focus()
+	ti.CharLimit = 500
+
+	return &ChatOverlay{
+		ctx:      ctx,
+		registry: reg,
+		aiCtx:    aiCtx,
+		styles:   newChatStyles(),
+		input:    ti,
+		sessMgr:  ai.NewSessionManager(maxSessions),
+		messages: []chatMessage{},
+	}
+}
+
+func (c *ChatOverlay) Init() tea.Cmd {
+	return tea.Batch(
+		textinput.Blink,
+		c.initClient,
+	)
+}
+
+func (c *ChatOverlay) initClient() tea.Msg {
+	executor, err := ai.NewToolExecutor(c.ctx, c.registry)
+	if err != nil {
+		return chatInitMsg{err: fmt.Errorf("init tool executor: %w", err)}
+	}
+
+	client, err := ai.NewClient(
+		c.ctx,
+		ai.WithModel(config.File().GetAIModel()),
+		ai.WithTools(executor.Tools()),
+	)
+	if err != nil {
+		return chatInitMsg{err: fmt.Errorf("init ai client: %w", err)}
+	}
+
+	session, err := c.sessMgr.NewSession(c.aiCtx)
+	if err != nil {
+		return chatInitMsg{err: fmt.Errorf("create session: %w", err)}
+	}
+
+	return chatInitMsg{client: client, executor: executor, session: session}
+}
+
+func (c *ChatOverlay) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case chatInitMsg:
+		if msg.err != nil {
+			c.err = msg.err
+		} else {
+			c.client = msg.client
+			c.executor = msg.executor
+			c.session = msg.session
+		}
+		return c, nil
+
+	case tea.KeyPressMsg:
+		return c.handleKeyPress(msg)
+
+	case chatStreamMsg:
+		return c.handleStreamEvent(msg.event)
+
+	case chatDoneMsg:
+		if msg.err != nil {
+			c.err = msg.err
+			c.isThinking = false
+		}
+		return c, nil
+	}
+
+	var cmds []tea.Cmd
+
+	if c.vp.Ready {
+		var cmd tea.Cmd
+		c.vp.Model, cmd = c.vp.Model.Update(msg)
+		cmds = append(cmds, cmd)
+	}
+
+	var cmd tea.Cmd
+	c.input, cmd = c.input.Update(msg)
+	cmds = append(cmds, cmd)
+
+	return c, tea.Batch(cmds...)
+}
+
+func (c *ChatOverlay) handleKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	if IsEscKey(msg) {
+		return c, func() tea.Msg { return HideModalMsg{} }
+	}
+
+	switch msg.String() {
+	case "enter":
+		if c.isThinking {
+			return c, nil
+		}
+
+		text := strings.TrimSpace(c.input.Value())
+		if text == "" {
+			return c, nil
+		}
+
+		c.input.SetValue("")
+		c.messages = append(c.messages, chatMessage{role: ai.RoleUser, content: text})
+		c.isThinking = true
+		c.streamingMsg = ""
+		c.err = nil
+		c.updateViewport()
+
+		return c, c.sendMessage()
+	}
+
+	var cmd tea.Cmd
+	c.input, cmd = c.input.Update(msg)
+	return c, cmd
+}
+
+func (c *ChatOverlay) sendMessage() tea.Cmd {
+	return func() tea.Msg {
+		if c.client == nil {
+			return chatDoneMsg{err: fmt.Errorf("client not initialized")}
+		}
+
+		messages := make([]ai.Message, len(c.messages))
+		for i, m := range c.messages {
+			messages[i] = ai.Message{Role: m.role, Content: m.content}
+		}
+
+		systemPrompt := c.buildSystemPrompt()
+		result, err := c.client.Converse(c.ctx, messages, systemPrompt)
+		if err != nil {
+			return chatDoneMsg{err: err}
+		}
+
+		for len(result.ToolCalls) > 0 {
+			var toolResults []ai.ToolResult
+			for _, tc := range result.ToolCalls {
+				tr := c.executor.Execute(c.ctx, tc)
+				toolResults = append(toolResults, tr)
+			}
+
+			messages = c.client.AddToolResultMessages(messages, result.ToolCalls, toolResults)
+
+			result, err = c.client.Converse(c.ctx, messages, systemPrompt)
+			if err != nil {
+				return chatDoneMsg{err: err}
+			}
+		}
+
+		return chatStreamMsg{event: ai.StreamEvent{Type: "done", Text: result.Message}}
+	}
+}
+
+func (c *ChatOverlay) handleStreamEvent(event ai.StreamEvent) (tea.Model, tea.Cmd) {
+	switch event.Type {
+	case "text":
+		c.streamingMsg += event.Text
+		c.updateViewport()
+
+	case "done":
+		if event.Text != "" {
+			c.messages = append(c.messages, chatMessage{role: ai.RoleAssistant, content: event.Text})
+		} else if c.streamingMsg != "" {
+			c.messages = append(c.messages, chatMessage{role: ai.RoleAssistant, content: c.streamingMsg})
+		}
+		c.streamingMsg = ""
+		c.isThinking = false
+		c.updateViewport()
+
+	case "error":
+		c.err = event.Error
+		c.isThinking = false
+	}
+
+	return c, nil
+}
+
+func (c *ChatOverlay) buildSystemPrompt() string {
+	prompt := `You are an AI assistant helping users explore and understand their AWS resources.
+You have access to tools that can list services, query resources, get resource details, and tail CloudWatch logs.
+Be concise but helpful. When showing resources, summarize key information.
+If the user asks about logs for a resource like Lambda, infer the log group name (e.g., /aws/lambda/{function-name}).`
+
+	if c.aiCtx != nil {
+		if c.aiCtx.Service != "" {
+			prompt += fmt.Sprintf("\n\nCurrent context: Service=%s", c.aiCtx.Service)
+			if c.aiCtx.ResourceType != "" {
+				prompt += fmt.Sprintf(", ResourceType=%s", c.aiCtx.ResourceType)
+			}
+			if c.aiCtx.ResourceID != "" {
+				prompt += fmt.Sprintf(", ResourceID=%s", c.aiCtx.ResourceID)
+			}
+		}
+	}
+
+	return prompt
+}
+
+func (c *ChatOverlay) updateViewport() {
+	if !c.vp.Ready {
+		return
+	}
+	content := c.renderMessages()
+	c.vp.Model.SetContent(content)
+	c.vp.Model.GotoBottom()
+}
+
+func (c *ChatOverlay) renderMessages() string {
+	var sb strings.Builder
+
+	for _, msg := range c.messages {
+		switch msg.role {
+		case ai.RoleUser:
+			sb.WriteString(c.styles.userMsg.Render("You: " + msg.content))
+		case ai.RoleAssistant:
+			sb.WriteString(c.styles.assistantMsg.Render("AI: " + msg.content))
+		}
+		sb.WriteString("\n\n")
+	}
+
+	if c.streamingMsg != "" {
+		sb.WriteString(c.styles.assistantMsg.Render("AI: " + c.streamingMsg))
+		sb.WriteString("\n")
+	}
+
+	if c.isThinking && c.streamingMsg == "" {
+		sb.WriteString(c.styles.thinking.Render("Thinking..."))
+		sb.WriteString("\n")
+	}
+
+	if c.err != nil {
+		sb.WriteString(lipgloss.NewStyle().Foreground(ui.Current().Danger).Render("Error: " + c.err.Error()))
+		sb.WriteString("\n")
+	}
+
+	return sb.String()
+}
+
+func (c *ChatOverlay) View() tea.View {
+	return tea.NewView(c.ViewString())
+}
+
+func (c *ChatOverlay) ViewString() string {
+	var sb strings.Builder
+
+	title := c.styles.title.Render("AI Chat")
+	sb.WriteString(title)
+	sb.WriteString("\n")
+
+	if c.aiCtx != nil && c.aiCtx.Service != "" {
+		ctx := fmt.Sprintf("Context: %s", c.aiCtx.Service)
+		if c.aiCtx.ResourceType != "" {
+			ctx += "/" + c.aiCtx.ResourceType
+		}
+		if c.aiCtx.ResourceName != "" {
+			ctx += " - " + c.aiCtx.ResourceName
+		}
+		sb.WriteString(c.styles.context.Render(ctx))
+		sb.WriteString("\n")
+	}
+	sb.WriteString("\n")
+
+	if c.vp.Ready {
+		sb.WriteString(c.vp.Model.View())
+	} else {
+		sb.WriteString(c.renderMessages())
+	}
+
+	sb.WriteString("\n")
+	sb.WriteString(c.styles.input.Render(c.input.View()))
+
+	return sb.String()
+}
+
+func (c *ChatOverlay) SetSize(width, height int) tea.Cmd {
+	c.width = width
+	c.height = height
+
+	vpHeight := height - 8
+	if vpHeight < 5 {
+		vpHeight = 5
+	}
+
+	c.vp.SetSize(width, vpHeight)
+	c.updateViewport()
+
+	return nil
+}
+
+func (c *ChatOverlay) StatusLine() string {
+	return "AI Chat | Enter: send | Esc: close"
+}
+
+func (c *ChatOverlay) HasActiveInput() bool {
+	return true
+}

--- a/internal/view/detail_view.go
+++ b/internal/view/detail_view.go
@@ -225,7 +225,6 @@ func (d *DetailView) SetSize(width, height int) tea.Cmd {
 	return nil
 }
 
-// StatusLine implements View
 func (d *DetailView) StatusLine() string {
 	parts := []string{d.resource.GetID()}
 
@@ -249,6 +248,18 @@ func (d *DetailView) StatusLine() string {
 
 	parts = append(parts, "q/esc:back")
 	return strings.Join(parts, " • ")
+}
+
+func (d *DetailView) Resource() dao.Resource {
+	return d.resource
+}
+
+func (d *DetailView) Service() string {
+	return d.service
+}
+
+func (d *DetailView) ResourceType() string {
+	return d.resType
 }
 
 // getNavigationShortcuts returns a string of navigation shortcuts for the current resource

--- a/internal/view/log_view.go
+++ b/internal/view/log_view.go
@@ -566,3 +566,7 @@ func (v *LogView) StatusLine() string {
 func (v *LogView) HasActiveInput() bool {
 	return v.filterActive
 }
+
+func (v *LogView) LogGroupName() string {
+	return v.logGroupName
+}

--- a/internal/view/resource_browser_nav.go
+++ b/internal/view/resource_browser_nav.go
@@ -160,9 +160,23 @@ func (r *ResourceBrowser) CanRefresh() bool {
 	return true
 }
 
-// Service returns the service name for this browser
 func (r *ResourceBrowser) Service() string {
 	return r.service
+}
+
+func (r *ResourceBrowser) ResourceType() string {
+	return r.resourceType
+}
+
+func (r *ResourceBrowser) SelectedResource() dao.Resource {
+	if len(r.filtered) == 0 {
+		return nil
+	}
+	cursor := r.tc.Cursor()
+	if cursor < 0 || cursor >= len(r.filtered) {
+		return nil
+	}
+	return r.filtered[cursor]
 }
 
 // getNavigationShortcuts returns a string of navigation shortcuts for the current resource


### PR DESCRIPTION
## Summary
Closes #123

Adds AI chat feature using Amazon Bedrock Converse API - a "self-hosted Amazon Q Developer" experience.

## Changes
- **internal/ai/bedrock.go**: Bedrock Converse API client with streaming
- **internal/ai/tools.go**: 6 tools (list_services, list_resources, query_resources, get_resource_detail, tail_logs, search_aws_docs)
- **internal/ai/session.go**: Chat session persistence (~/.config/claws/chat/sessions/)
- **internal/view/chat_overlay.go**: Modal UI (viewport + textinput)
- **internal/config/file.go**: AIConfig (model, max_sessions)
- **internal/app/app.go**: `A` keybind opens chat overlay
- View getters for context awareness

## Usage
- Press `A` to open chat overlay
- AI knows current service/resource/log group context
- Configure model in `~/.config/claws/config.yaml`:
  ```yaml
  ai:
    model: "global.anthropic.claude-haiku-4-5-20251001-v1:0"
    max_sessions: 10
  ```

## Testing
- [x] Build passes
- [x] Lint passes
- [x] Tests pass
- [ ] Manual testing needed