### PR TITLE
fix: don't show suggestion for empty input

### DIFF
--- a/internal/view/command_input.go
+++ b/internal/view/command_input.go
@@ -221,6 +221,11 @@ func (c *CommandInput) updateWidth() {
 func (c *CommandInput) renderInputWithSuggestion(s commandInputStyles, input string) string {
 	baseView := c.textInput.View()
 
+	// No suggestion for empty input
+	if input == "" {
+		return s.input.Render(baseView)
+	}
+
 	// Find first suggestion that extends current input
 	var suffix string
 	for _, sugg := range c.suggestions {

--- a/internal/view/command_input_test.go
+++ b/internal/view/command_input_test.go
@@ -785,6 +785,7 @@ func TestCommandInput_FishStyleSuggestion(t *testing.T) {
 		input      string
 		wantSuffix string // suffix should appear in view (dim)
 	}{
+		{"empty input", "", ""},                     // no suggestion for empty
 		{"partial service", "ec", "2"},              // ec -> ec2
 		{"service with slash", "ec2/", "instances"}, // ec2/ -> ec2/instances
 		{"partial resource", "ec2/in", "stances"},   // ec2/in -> ec2/instances


### PR DESCRIPTION
## Summary
- Empty input matched all suggestions via `HasPrefix("", ...)` causing random text to appear next to placeholder

## Test plan
- [x] Added empty input test case
- [x] Verify no suggestion appears when command input is empty