### PR TITLE
v0.14.0: Compact header mode

### DIFF
--- a/cmd/claws/main.go
+++ b/cmd/claws/main.go
@@ -53,6 +53,14 @@ func main() {
 	}
 	cfg.SetReadOnly(opts.readOnly)
 
+	var compactHeader bool
+	if opts.compactHeader != nil {
+		compactHeader = *opts.compactHeader
+	} else {
+		compactHeader = fileCfg.GetCompactHeader()
+	}
+	cfg.SetCompactHeader(compactHeader)
+
 	for _, p := range opts.profiles {
 		if !config.IsValidProfileName(p) {
 			fmt.Fprintf(os.Stderr, "Error: invalid profile name: %s\n", p)
@@ -116,16 +124,17 @@ func main() {
 }
 
 type cliOptions struct {
-	profiles   []string
-	regions    []string
-	readOnly   bool
-	envCreds   bool
-	autosave   *bool
-	logFile    string
-	configFile string
-	service    string
-	resourceID string
-	theme      string
+	profiles      []string
+	regions       []string
+	readOnly      bool
+	envCreds      bool
+	autosave      *bool
+	logFile       string
+	configFile    string
+	service       string
+	resourceID    string
+	theme         string
+	compactHeader *bool
 }
 
 // parseFlags parses command line flags and returns options
@@ -194,6 +203,12 @@ func parseFlagsFromArgs(args []string) cliOptions {
 				i++
 				opts.theme = args[i]
 			}
+		case "--compact":
+			t := true
+			opts.compactHeader = &t
+		case "--no-compact":
+			f := false
+			opts.compactHeader = &f
 		case "-h", "--help":
 			showHelp = true
 		case "-v", "--version":
@@ -245,6 +260,10 @@ func printUsage() {
 	fmt.Println("        Enable debug logging to specified file")
 	fmt.Println("  -t, --theme <name>")
 	fmt.Println("        Color theme: dark, light, nord, dracula, gruvbox, catppuccin")
+	fmt.Println("  --compact")
+	fmt.Println("        Start with compact header mode (toggle with Ctrl+E)")
+	fmt.Println("  --no-compact")
+	fmt.Println("        Disable compact header (overrides config file)")
 	fmt.Println("  -v, --version")
 	fmt.Println("        Show version")
 	fmt.Println("  -h, --help")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,7 +49,9 @@ cloudwatch:
   window: 15m             # Metrics data window period (default: 15m)
 
 autosave:
-  enabled: true           # Save region/profile/theme on change (default: false)
+  enabled: true           # Save region/profile/theme/compact_header on change (default: false)
+
+compact_header: false     # Use single-line compact header (default: false)
 
 startup:                  # Applied on launch if present
   view: services          # Startup view: "dashboard", "services", or "service/resource" (e.g., "ec2", "rds/snapshots")
@@ -84,7 +86,7 @@ theme: nord               # Preset: dark, light, nord, dracula, gruvbox, catppuc
 
 The config file is **not created automatically**. Create it manually if needed.
 
-CLI flags (`-p`, `-r`, `-t`, `--autosave`, `--no-autosave`) override config file settings.
+CLI flags (`-p`, `-r`, `-t`, `--compact`, `--no-compact`, `--autosave`, `--no-autosave`) override config file settings.
 Multiple values supported: `-p dev,prod` or `-p dev -p prod`.
 
 ### Special Profile IDs

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -23,6 +23,7 @@ Complete reference for all keyboard shortcuts in claws.
 | `:services` | Go to service browser |
 | `/` | Filter mode (fuzzy search) |
 | `A` | AI Chat (Bedrock) |
+| `Ctrl+E` | Toggle compact header |
 | `?` | Show help |
 
 ## Resource Browser
@@ -63,6 +64,7 @@ Complete reference for all keyboard shortcuts in claws.
 | `:diff <n1> <n2>` | Compare two named resources |
 | `:theme <name>` | Change color theme |
 | `:autosave on/off` | Enable/disable config autosave |
+| `:settings` | Show current settings |
 | `:clear-history` | Clear navigation history (stack) |
 
 ## Mouse Support

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -227,6 +227,15 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return a, nil
 
+	case view.CompactHeaderChangedMsg:
+		if a.currentView != nil {
+			a.currentView.Update(msg)
+		}
+		for _, v := range a.viewStack {
+			v.Update(msg)
+		}
+		return a, nil
+
 	case view.ThemeChangeMsg:
 		theme := ui.GetPreset(msg.Name)
 		if theme == nil {
@@ -340,6 +349,16 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				chatOverlay.Init(),
 				a.modal.SetSize(a.width, a.height),
 			)
+
+		case key.Matches(msg, a.keys.CompactHeader):
+			compact := !config.Global().CompactHeader()
+			config.Global().SetCompactHeader(compact)
+			if config.File().PersistenceEnabled() {
+				if err := config.File().SaveCompactHeader(compact); err != nil {
+					log.Warn("failed to persist compact header", "error", err)
+				}
+			}
+			return a, func() tea.Msg { return view.CompactHeaderChangedMsg{} }
 		}
 
 	case view.ShowModalMsg:
@@ -504,7 +523,7 @@ func (a *App) View() tea.View {
 
 	var statusContent string
 	if a.commandMode {
-		statusContent = a.commandInput.View() + " • Esc:cancel Enter:run Tab:complete"
+		statusContent = a.commandInput.View() + ui.DimStyle().Render(" • Esc:cancel Enter:run Tab:complete")
 	} else {
 		if a.err != nil {
 			statusContent = ui.DangerStyle().Render("Error: " + a.err.Error())
@@ -774,17 +793,18 @@ func (a *App) refreshCurrentView() (tea.Model, tea.Cmd) {
 }
 
 type keyMap struct {
-	Up      key.Binding
-	Down    key.Binding
-	Enter   key.Binding
-	Back    key.Binding
-	Filter  key.Binding
-	Command key.Binding
-	Region  key.Binding
-	Profile key.Binding
-	AI      key.Binding
-	Help    key.Binding
-	Quit    key.Binding
+	Up            key.Binding
+	Down          key.Binding
+	Enter         key.Binding
+	Back          key.Binding
+	Filter        key.Binding
+	Command       key.Binding
+	Region        key.Binding
+	Profile       key.Binding
+	AI            key.Binding
+	CompactHeader key.Binding
+	Help          key.Binding
+	Quit          key.Binding
 }
 
 func defaultKeyMap() keyMap {
@@ -824,6 +844,10 @@ func defaultKeyMap() keyMap {
 		AI: key.NewBinding(
 			key.WithKeys("A"),
 			key.WithHelp("A", "ai chat"),
+		),
+		CompactHeader: key.NewBinding(
+			key.WithKeys("ctrl+e"),
+			key.WithHelp("ctrl+e", "compact header"),
 		),
 		Help: key.NewBinding(
 			key.WithKeys("?"),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -176,12 +176,13 @@ func (s ProfileSelection) ID() string {
 }
 
 type Config struct {
-	mu         sync.RWMutex
-	regions    []string
-	selections []ProfileSelection
-	accountIDs map[string]string
-	warnings   []string
-	readOnly   bool
+	mu            sync.RWMutex
+	regions       []string
+	selections    []ProfileSelection
+	accountIDs    map[string]string
+	warnings      []string
+	readOnly      bool
+	compactHeader bool
 }
 
 var (
@@ -344,6 +345,14 @@ func (c *Config) ReadOnly() bool {
 
 func (c *Config) SetReadOnly(readOnly bool) {
 	doWithLock(&c.mu, func() { c.readOnly = readOnly })
+}
+
+func (c *Config) CompactHeader() bool {
+	return withRLock(&c.mu, func() bool { return c.compactHeader })
+}
+
+func (c *Config) SetCompactHeader(compact bool) {
+	doWithLock(&c.mu, func() { c.compactHeader = compact })
 }
 
 func (c *Config) AddWarning(msg string) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -89,6 +89,27 @@ func TestConfig_ReadOnlyGetSet(t *testing.T) {
 	}
 }
 
+func TestConfig_CompactHeaderGetSet(t *testing.T) {
+	cfg := &Config{}
+
+	// Initial value should be false
+	if cfg.CompactHeader() {
+		t.Error("CompactHeader() = true, want false")
+	}
+
+	// Set to true
+	cfg.SetCompactHeader(true)
+	if !cfg.CompactHeader() {
+		t.Error("CompactHeader() = false, want true")
+	}
+
+	// Set back to false
+	cfg.SetCompactHeader(false)
+	if cfg.CompactHeader() {
+		t.Error("CompactHeader() = true, want false")
+	}
+}
+
 func TestConfig_Warnings(t *testing.T) {
 	cfg := &Config{}
 

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -209,6 +209,7 @@ type FileConfig struct {
 	Theme               ThemeConfig       `yaml:"theme,omitempty"`
 	Navigation          NavigationConfig  `yaml:"navigation,omitempty"`
 	AI                  AIConfig          `yaml:"ai,omitempty"`
+	CompactHeader       bool              `yaml:"compact_header,omitempty"`
 }
 
 // Duration wraps time.Duration for YAML marshal/unmarshal as string (e.g., "5s", "30s")
@@ -590,6 +591,23 @@ func (c *FileConfig) SavePersistence(enabled bool) error {
 		autosaveNode := findOrCreateMappingKey(mapping, "autosave")
 		ensureMappingNode(autosaveNode)
 		setBoolValue(autosaveNode, "enabled", enabled)
+	})
+}
+
+func (c *FileConfig) GetCompactHeader() bool {
+	return withRLock(&c.mu, func() bool {
+		return c.CompactHeader
+	})
+}
+
+func (c *FileConfig) SaveCompactHeader(compact bool) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.CompactHeader = compact
+
+	return c.patchConfigLocked(func(mapping *yaml.Node) {
+		setBoolValue(mapping, "compact_header", compact)
 	})
 }
 

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"charm.land/bubbles/v2/spinner"
+	"charm.land/bubbles/v2/textinput"
 	"charm.land/lipgloss/v2"
 
 	"github.com/clawscli/claws/internal/config"
@@ -471,4 +472,18 @@ func NewSpinner() spinner.Model {
 	s.Spinner = spinner.Dot
 	s.Style = lipgloss.NewStyle().Foreground(Current().Accent)
 	return s
+}
+
+func TextInputStyles() textinput.Styles {
+	t := Current()
+	state := textinput.StyleState{
+		Text:        lipgloss.NewStyle().Foreground(t.Text),
+		Placeholder: lipgloss.NewStyle().Foreground(t.TextDim),
+		Suggestion:  lipgloss.NewStyle().Foreground(t.TextDim),
+		Prompt:      lipgloss.NewStyle().Foreground(t.Text),
+	}
+	return textinput.Styles{
+		Focused: state,
+		Blurred: state,
+	}
 }

--- a/internal/view/command_input.go
+++ b/internal/view/command_input.go
@@ -38,7 +38,7 @@ func newCommandInputStyles() commandInputStyles {
 		input:      ui.InputFieldStyle(),
 		suggestion: ui.DimStyle(),
 		highlight:  ui.HighlightStyle(),
-		alias:      ui.NoStyle(), // Normal text, not dimmed
+		alias:      ui.TextStyle(),
 	}
 }
 
@@ -80,6 +80,7 @@ func NewCommandInput(ctx context.Context, reg *registry.Registry) *CommandInput 
 	ti.Prompt = ":"
 	ti.CharLimit = 150
 	ti.SetWidth(commandInputWidth1)
+	ti.SetStyles(ui.TextInputStyles())
 
 	return &CommandInput{
 		ctx:       ctx,
@@ -101,6 +102,7 @@ func (c *CommandInput) Activate() tea.Cmd {
 
 func (c *CommandInput) ReloadStyles() {
 	c.styles = newCommandInputStyles()
+	c.textInput.SetStyles(ui.TextInputStyles())
 }
 
 // Deactivate deactivates command mode
@@ -314,7 +316,7 @@ func (c *CommandInput) View() string {
 			if len(c.suggestions) > maxShow+1 {
 				suggText += " ..."
 			}
-			suggView = s.alias.Render(suggText) // alias = NoStyle (white)
+			suggView = s.alias.Render(suggText)
 		}
 	}
 

--- a/internal/view/dashboard_view.go
+++ b/internal/view/dashboard_view.go
@@ -192,6 +192,9 @@ func (d *DashboardView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		d.styles = newDashboardStyles()
 		d.headerPanel.ReloadStyles()
 		return d, nil
+	case CompactHeaderChangedMsg:
+		d.lastHeaderHeight = 0 // force hitAreas rebuild
+		return d, nil
 
 	case tea.MouseClickMsg:
 		return d.handleMouseClick(msg)

--- a/internal/view/header_panel_test.go
+++ b/internal/view/header_panel_test.go
@@ -1,0 +1,330 @@
+package view
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/clawscli/claws/internal/config"
+	"github.com/clawscli/claws/internal/render"
+)
+
+func TestHeaderPanel_New(t *testing.T) {
+	hp := NewHeaderPanel()
+
+	if hp == nil {
+		t.Fatal("NewHeaderPanel() returned nil")
+	}
+}
+
+func TestHeaderPanel_RenderNormalMode(t *testing.T) {
+	cfg := config.Global()
+	t.Cleanup(func() { cfg.SetCompactHeader(false) })
+	cfg.SetCompactHeader(false)
+
+	hp := NewHeaderPanel()
+	hp.SetWidth(80)
+
+	output := hp.Render("ec2", "instances", nil)
+
+	lines := strings.Count(output, "\n")
+	if lines < 3 {
+		t.Errorf("Normal mode should have multiple lines (at least 4), got %d lines", lines+1)
+	}
+
+	if !strings.Contains(output, "Profile:") {
+		t.Error("Normal mode output should contain 'Profile:' label")
+	}
+	if !strings.Contains(output, "Region:") {
+		t.Error("Normal mode output should contain 'Region:' label")
+	}
+}
+
+func TestHeaderPanel_RenderCompactMode(t *testing.T) {
+	cfg := config.Global()
+	t.Cleanup(func() { cfg.SetCompactHeader(false) })
+	cfg.SetCompactHeader(true)
+
+	hp := NewHeaderPanel()
+	hp.SetWidth(80)
+
+	output := hp.Render("ec2", "instances", nil)
+
+	lines := strings.Count(output, "\n")
+	if lines > 3 {
+		t.Errorf("Compact mode should have minimal lines (1-2), got %d lines", lines+1)
+	}
+
+	if !strings.Contains(output, "│") {
+		t.Error("Compact mode output should contain '│' separator")
+	}
+}
+
+func TestHeaderPanel_RenderModeSwitching(t *testing.T) {
+	cfg := config.Global()
+	t.Cleanup(func() { cfg.SetCompactHeader(false) })
+	hp := NewHeaderPanel()
+	hp.SetWidth(80)
+
+	cfg.SetCompactHeader(false)
+	normalOutput := hp.Render("ec2", "instances", nil)
+	normalLines := strings.Count(normalOutput, "\n")
+
+	cfg.SetCompactHeader(true)
+	compactOutput := hp.Render("ec2", "instances", nil)
+	compactLines := strings.Count(compactOutput, "\n")
+
+	if normalLines <= compactLines {
+		t.Errorf("Normal mode should have more lines than Compact mode. Normal: %d, Compact: %d", normalLines+1, compactLines+1)
+	}
+}
+
+func TestHeaderPanel_RenderHome(t *testing.T) {
+	cfg := config.Global()
+	t.Cleanup(func() { cfg.SetCompactHeader(false) })
+	hp := NewHeaderPanel()
+	hp.SetWidth(80)
+
+	cfg.SetCompactHeader(false)
+	output := hp.RenderHome()
+
+	if !strings.Contains(output, "Profile:") {
+		t.Error("RenderHome() should contain 'Profile:' label")
+	}
+	if !strings.Contains(output, "Region:") {
+		t.Error("RenderHome() should contain 'Region:' label")
+	}
+}
+
+func TestHeaderPanel_RenderHomeCompact(t *testing.T) {
+	cfg := config.Global()
+	t.Cleanup(func() { cfg.SetCompactHeader(false) })
+	hp := NewHeaderPanel()
+	hp.SetWidth(80)
+
+	cfg.SetCompactHeader(true)
+	output := hp.RenderHome()
+
+	if !strings.Contains(output, "│") {
+		t.Error("RenderHome() in compact mode should contain '│' separator")
+	}
+}
+
+func TestHeaderPanel_RenderWithSummaryFields(t *testing.T) {
+	cfg := config.Global()
+	t.Cleanup(func() { cfg.SetCompactHeader(false) })
+	cfg.SetCompactHeader(false)
+
+	hp := NewHeaderPanel()
+	hp.SetWidth(80)
+
+	summaryFields := []render.SummaryField{
+		{Label: "ID", Value: "i-1234567890abcdef0"},
+		{Label: "State", Value: "running"},
+		{Label: "Type", Value: "t3.medium"},
+	}
+
+	output := hp.Render("ec2", "instances", summaryFields)
+
+	if !strings.Contains(output, "ID:") {
+		t.Error("Output should contain 'ID:' label from summary fields")
+	}
+	if !strings.Contains(output, "State:") {
+		t.Error("Output should contain 'State:' label from summary fields")
+	}
+}
+
+func TestHeaderPanel_Height(t *testing.T) {
+	cfg := config.Global()
+	t.Cleanup(func() { cfg.SetCompactHeader(false) })
+
+	hp := NewHeaderPanel()
+	hp.SetWidth(80)
+	cfg.SetCompactHeader(false)
+
+	output := hp.Render("ec2", "instances", nil)
+	height := hp.Height(output)
+
+	if height < 1 {
+		t.Errorf("Height() should return positive value, got %d", height)
+	}
+
+	expectedHeight := strings.Count(output, "\n") + 1
+	if height != expectedHeight {
+		t.Errorf("Height() = %d, want %d based on newline count", height, expectedHeight)
+	}
+}
+
+func TestFormatRegions(t *testing.T) {
+	valueStyle := lipgloss.NewStyle()
+
+	tests := []struct {
+		name       string
+		regions    []string
+		maxWidth   int
+		wantSuffix string
+		notWant    string
+	}{
+		{
+			name:       "empty regions",
+			regions:    nil,
+			maxWidth:   100,
+			wantSuffix: "-",
+		},
+		{
+			name:       "single region",
+			regions:    []string{"us-east-1"},
+			maxWidth:   100,
+			wantSuffix: "us-east-1",
+			notWant:    "(+",
+		},
+		{
+			name:       "two regions fit",
+			regions:    []string{"us-east-1", "us-west-2"},
+			maxWidth:   100,
+			wantSuffix: "us-west-2",
+			notWant:    "(+",
+		},
+		{
+			name:       "narrow width truncates",
+			regions:    []string{"us-east-1", "us-west-2", "eu-west-1"},
+			maxWidth:   25,
+			wantSuffix: "(+2)",
+		},
+		{
+			name:       "non-positive width truncates",
+			regions:    []string{"us-east-1", "us-west-2", "eu-west-1"},
+			maxWidth:   0,
+			wantSuffix: "(+2)",
+			notWant:    "us-west-2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatRegions(tt.regions, valueStyle, tt.maxWidth)
+
+			if !strings.Contains(result, tt.wantSuffix) {
+				t.Errorf("formatRegions() = %q, want to contain %q", result, tt.wantSuffix)
+			}
+
+			if tt.notWant != "" && strings.Contains(result, tt.notWant) {
+				t.Errorf("formatRegions() = %q, should not contain %q", result, tt.notWant)
+			}
+		})
+	}
+}
+
+func TestFormatProfilesWithAccounts(t *testing.T) {
+	valueStyle := lipgloss.NewStyle()
+	dangerStyle := lipgloss.NewStyle()
+
+	tests := []struct {
+		name       string
+		selections []config.ProfileSelection
+		accountIDs map[string]string
+		maxWidth   int
+		wantSuffix string
+		notWant    string
+	}{
+		{
+			name:       "empty selections",
+			selections: nil,
+			accountIDs: nil,
+			maxWidth:   100,
+			wantSuffix: "-",
+		},
+		{
+			name: "single profile fits",
+			selections: []config.ProfileSelection{
+				config.NamedProfile("dev"),
+			},
+			accountIDs: map[string]string{"dev": "111111111111"},
+			maxWidth:   100,
+			wantSuffix: "dev",
+			notWant:    "(+",
+		},
+		{
+			name: "two profiles fit without suffix",
+			selections: []config.ProfileSelection{
+				config.NamedProfile("dev"),
+				config.NamedProfile("prod"),
+			},
+			accountIDs: map[string]string{
+				"dev":  "111111111111",
+				"prod": "222222222222",
+			},
+			maxWidth:   200,
+			wantSuffix: "prod",
+			notWant:    "(+",
+		},
+		{
+			name: "narrow width truncates second profile",
+			selections: []config.ProfileSelection{
+				config.NamedProfile("dev"),
+				config.NamedProfile("prod"),
+			},
+			accountIDs: map[string]string{
+				"dev":  "111111111111",
+				"prod": "222222222222",
+			},
+			maxWidth:   25,
+			wantSuffix: "(+1)",
+		},
+		{
+			name: "very narrow width truncates all but first",
+			selections: []config.ProfileSelection{
+				config.NamedProfile("dev"),
+				config.NamedProfile("staging"),
+				config.NamedProfile("prod"),
+			},
+			accountIDs: map[string]string{
+				"dev":     "111111111111",
+				"staging": "222222222222",
+				"prod":    "333333333333",
+			},
+			maxWidth:   30,
+			wantSuffix: "(+2)",
+		},
+		{
+			name: "non-positive width truncates",
+			selections: []config.ProfileSelection{
+				config.NamedProfile("dev"),
+				config.NamedProfile("staging"),
+				config.NamedProfile("prod"),
+			},
+			accountIDs: map[string]string{
+				"dev":     "111111111111",
+				"staging": "222222222222",
+				"prod":    "333333333333",
+			},
+			maxWidth:   0,
+			wantSuffix: "(+2)",
+			notWant:    "staging",
+		},
+		{
+			name: "missing account shows danger style",
+			selections: []config.ProfileSelection{
+				config.NamedProfile("dev"),
+			},
+			accountIDs: map[string]string{},
+			maxWidth:   100,
+			wantSuffix: "(-)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatProfilesWithAccounts(tt.selections, tt.accountIDs, valueStyle, dangerStyle, tt.maxWidth)
+
+			if !strings.Contains(result, tt.wantSuffix) {
+				t.Errorf("formatProfilesWithAccounts() = %q, want to contain %q", result, tt.wantSuffix)
+			}
+
+			if tt.notWant != "" && strings.Contains(result, tt.notWant) {
+				t.Errorf("formatProfilesWithAccounts() = %q, should not contain %q", result, tt.notWant)
+			}
+		})
+	}
+}

--- a/internal/view/help_view.go
+++ b/internal/view/help_view.go
@@ -149,6 +149,7 @@ func (h *HelpView) renderContent() string {
 	out += "\n" + s.section.Render("Global") + "\n"
 	out += s.key.Render("R") + s.desc.Render("Switch AWS region") + "\n"
 	out += s.key.Render("P") + s.desc.Render("Switch AWS profile") + "\n"
+	out += s.key.Render("Ctrl+E") + s.desc.Render("Toggle compact header") + "\n"
 	out += s.key.Render("?") + s.desc.Render("Show this help") + "\n"
 
 	// Command examples

--- a/internal/view/modal.go
+++ b/internal/view/modal.go
@@ -23,7 +23,7 @@ const (
 	ModalWidthProfile       = 55
 	ModalWidthProfileDetail = 65
 	ModalWidthActionMenu    = 60
-	ModalWidthSettings      = 70
+	ModalWidthSettings      = 75
 	ModalWidthChat          = 80
 )
 

--- a/internal/view/resource_browser.go
+++ b/internal/view/resource_browser.go
@@ -224,6 +224,9 @@ func (r *ResourceBrowser) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		r.headerPanel.ReloadStyles()
 		r.buildTable()
 		return r, nil
+	case CompactHeaderChangedMsg:
+		r.buildTable()
+		return r, nil
 	case SortMsg:
 		return r.handleSortMsg(msg)
 	case TagFilterMsg:

--- a/internal/view/service_browser.go
+++ b/internal/view/service_browser.go
@@ -48,7 +48,9 @@ type ServiceBrowser struct {
 	headerPanel *HeaderPanel
 
 	// Viewport for scrolling
-	vp ViewportState
+	vp     ViewportState
+	width  int
+	height int
 
 	// Filter
 	filterInput  textinput.Model
@@ -175,6 +177,10 @@ func (s *ServiceBrowser) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case ThemeChangedMsg:
 		s.styles = newServiceBrowserStyles()
 		s.headerPanel.ReloadStyles()
+		s.updateViewport()
+		return s, nil
+	case CompactHeaderChangedMsg:
+		s.recalcViewport()
 		return s, nil
 
 	case tea.KeyPressMsg:
@@ -572,22 +578,29 @@ func (s *ServiceBrowser) renderCell(item serviceItem, selected bool) string {
 
 // SetSize implements View
 func (s *ServiceBrowser) SetSize(width, height int) tea.Cmd {
+	s.width = width
+	s.height = height
+
 	// Set header panel width
 	s.headerPanel.SetWidth(width)
 
 	// Calculate columns based on width
 	s.cols = max(minColumns, min((width-cellPaddingX)/cellWidth, maxColumns))
 
+	s.recalcViewport()
+
+	return nil
+}
+
+func (s *ServiceBrowser) recalcViewport() {
 	// Calculate header height dynamically
 	headerStr := s.headerPanel.RenderHome()
 	headerHeight := s.headerPanel.Height(headerStr)
 
-	vpHeight := max(height-headerHeight+1, 5)
+	vpHeight := max(s.height-headerHeight+1, 5)
 
-	s.vp.SetSize(width, vpHeight)
+	s.vp.SetSize(s.width, vpHeight)
 	s.vp.Model.SetContent(s.renderContent())
-
-	return nil
 }
 
 // StatusLine implements View

--- a/internal/view/settings_view_test.go
+++ b/internal/view/settings_view_test.go
@@ -96,7 +96,6 @@ func TestSettingsView_BuildContent(t *testing.T) {
 	expectedSections := []string{
 		"Config File",
 		"Runtime",
-		"Startup",
 		"Theme",
 		"Timeouts",
 		"Concurrency",
@@ -109,6 +108,19 @@ func TestSettingsView_BuildContent(t *testing.T) {
 	for _, section := range expectedSections {
 		if !strings.Contains(content, section) {
 			t.Errorf("buildContent() should contain section %q", section)
+		}
+	}
+
+	expectedFields := []string{
+		"Compact",
+		"Read-only",
+		"Regions",
+		"Profiles",
+	}
+
+	for _, field := range expectedFields {
+		if !strings.Contains(content, field) {
+			t.Errorf("buildContent() should contain field %q", field)
 		}
 	}
 }
@@ -153,19 +165,5 @@ func TestSettingsView_FormatProfiles_Empty(t *testing.T) {
 	result = sv.formatProfiles([]config.ProfileSelection{})
 	if result != noneValue {
 		t.Errorf("formatProfiles([]) should return %q, got %q", noneValue, result)
-	}
-}
-
-func TestSettingsView_GetProfileIDs(t *testing.T) {
-	sv := NewSettingsView(context.Background())
-
-	ids := sv.getProfileIDs(nil)
-	if len(ids) != 0 {
-		t.Errorf("getProfileIDs(nil) should return empty slice, got %d items", len(ids))
-	}
-
-	ids = sv.getProfileIDs([]config.ProfileSelection{})
-	if len(ids) != 0 {
-		t.Errorf("getProfileIDs([]) should return empty slice, got %d items", len(ids))
 	}
 }

--- a/internal/view/view.go
+++ b/internal/view/view.go
@@ -67,6 +67,9 @@ type RefreshMsg struct{}
 // ThemeChangedMsg tells views to reload their cached styles
 type ThemeChangedMsg struct{}
 
+// CompactHeaderChangedMsg tells views to update header rendering
+type CompactHeaderChangedMsg struct{}
+
 type ThemeChangeMsg struct {
 	Name string
 }


### PR DESCRIPTION
## Summary
- Add compact header mode (1-2 lines vs 5 lines) toggleable via `Ctrl+E`
- Support `--compact`/`--no-compact` CLI flags
- Add `compact_header` config setting with autosave support
- Dynamic profile/region width calculation with proper truncation

## Changes
- 20 commits from feature/header-redesign
- New `CompactHeaderChangedMsg` message type
- Full test coverage for formatting functions
- Docs: keybindings.md, configuration.md updated