### PR TITLE
ECS Services Page AutoReload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@v7
         with:
           version: "~> v2"
           args: release --clean

--- a/custom/ecs/clusters/render.go
+++ b/custom/ecs/clusters/render.go
@@ -194,6 +194,7 @@ func (r *ClusterRenderer) Navigations(resource dao.Resource) []render.Navigation
 			Resource:    "services",
 			FilterField: "ClusterName",
 			FilterValue: clusterName,
+			AutoReload:  true,
 		},
 		{
 			Key:         "t",


### PR DESCRIPTION
This PR enables auto reload on the ECS services page. This helps users follow the rollout of their services more easily.